### PR TITLE
Parallelize travis tests within a single vm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,10 @@ install:
   - . ./scripts/create_testenv.sh
   - conda install --yes sphinx ipython
   - pip install -I git+https://github.com/Syntaf/travis-sphinx.git
-  - pip install coveralls nbsphinx sphinx_rtd_theme
-
-env:
-  - TESTCMD="--cov-append csrank/tests/test_choice_functions.py"
-  - TESTCMD="--cov-append csrank/tests/test_discrete_choice.py"
-  - TESTCMD="--cov-append csrank/tests/test_ranking.py"
-  - TESTCMD="--cov-append csrank/tests/test_fate.py csrank/tests/test_losses.py csrank/tests/test_metrics.py csrank/tests/test_tuning.py csrank/tests/test_util.py"
+  - pip install coveralls nbsphinx sphinx_rtd_theme pytest pytest-xdist
 
 script:
-  - pytest -v --cov=csrank --ignore experiments $TESTCMD
+  - pytest -v --cov=csrank --ignore experiments --numprocesses=auto
   - travis-sphinx build -n --source=docs
 
 after_success:


### PR DESCRIPTION
## Description

Let pytest-xdist handle the parallelization instead of manually
specifying a split. Should run on at least two cores:
https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system

This is an experiment to compare the runtime with https://github.com/kiudee/cs-ranking/pull/64/files.

## Motivation and Context

The tests are too slow and manually specifying a split as done in https://github.com/kiudee/cs-ranking/pull/64 is error-prone.

## Does this close/impact existing issues?

#51, #64

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
