### PR TITLE
Fix accidental escapes in strings

### DIFF
--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -21,17 +21,19 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
             objects and the pairwise predicate is evaluated using them. The outputs of the network for each pair of
             objects :math:`U(x_1,x_2), U(x_2,x_1)` are evaluated.
             :math:`U(x_1,x_2)` is a measure of how favorable it is to choose :math:`x_1` over :math:`x_2`.
-            The utility score of object :math:`x_i` in query set :math:`Q = \{ x_1 , \ldots , x_n \}` is evaluated as:
+            The utility score of object :math:`x_i` in query set
+            :math:`Q = \\{ x_1 , \\ldots , x_n \\}` is evaluated as:
 
             .. math::
 
-                U(x_i) = \left\{ \\frac{1}{n-1} \sum_{j \in [n] \setminus \{i\}} U_1(x_i , x_j)\\right\}
+                U(x_i) = \\left\\{ \\frac{1}{n-1} \\sum_{j \\in [n]
+                \\setminus \\{i\\}} U_1(x_i , x_j)\\right\\}
 
             The choice set is defined as:
 
             .. math::
 
-                c(Q) = \{ x_i \in Q \lvert \, U(x_i) > t \}
+                c(Q) = \\{ x_i \\in Q \\lvert \\, U(x_i) > t \\}
 
             Parameters
             ----------
@@ -94,15 +96,15 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
         """
             Fit a CmptNet model for learning a choice fucntion on the provided set of queries X and preferences Y of
             those objects. The provided queries and corresponding preferences are of a fixed size (numpy arrays). For
-            learning this network the binary cross entropy loss function for a pair of objects :math:`x_i, x_j \in Q`
+            learning this network the binary cross entropy loss function for a pair of objects :math:`x_i, x_j \\in Q`
             is defined as:
 
             .. math::
 
-                C_{ij} =  -\\tilde{P_{ij}}(0)\\cdot \log(U(x_i,x_j)) - \\tilde{P_{ij}}(1) \\cdot \log(U(x_j,x_i)) \ ,
+                C_{ij} =  -\\tilde{P_{ij}}(0)\\cdot \\log(U(x_i,x_j)) - \\tilde{P_{ij}}(1) \\cdot \\log(U(x_j,x_i)) \\ ,
 
             where :math:`\\tilde{P_{ij}}` is ground truth probability of the preference of :math:`x_i` over :math:`x_j`.
-            :math:`\\tilde{P_{ij}} = (1,0)` if :math:`x_i \succ x_j` else :math:`\\tilde{P_{ij}} = (0,1)`.
+            :math:`\\tilde{P_{ij}} = (1,0)` if :math:`x_i \\succ x_j` else :math:`\\tilde{P_{ij}} = (0,1)`.
 
             Parameters
             ----------

--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -27,13 +27,13 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
             .. math::
                 \\mu_{C(x)} = \\frac{1}{\\lvert C(x) \\lvert} \\sum_{y \\in C(x)} \\phi(y)
 
-            where :math:`\phi \colon \mathcal{X} \\to \mathcal{Z}` maps each object :math:`y` to an
-            :math:`m`-dimensional embedding space :math:`\mathcal{Z} \subseteq \mathbb{R}^m`.
+            where :math:`\\phi \\colon \\mathcal{X} \\to \\mathcal{Z}` maps each object :math:`y` to an
+            :math:`m`-dimensional embedding space :math:`\\mathcal{Z} \\subseteq \\mathbb{R}^m`.
             The choice set is defined as:
 
             .. math::
 
-                c(Q) = \{ x \in Q \lvert \, U (x, \\mu_{C(x)}) > t \}
+                c(Q) = \\{ x \\in Q \\lvert \\, U (x, \\mu_{C(x)}) > t \\}
 
 
             Parameters

--- a/csrank/choicefunction/fatelinear_choice.py
+++ b/csrank/choicefunction/fatelinear_choice.py
@@ -21,14 +21,14 @@ class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
             .. math::
                 \\mu_{C(x)} = \\frac{1}{\\lvert C(x) \\lvert} \\sum_{y \\in C(x)} \\phi(y)
 
-            where :math:`\phi \colon \mathcal{X} \\to \mathcal{Z}` maps each object :math:`y` to an
-            :math:`m`-dimensional embedding space :math:`\mathcal{Z} \subseteq \mathbb{R}^m`.
+            where :math:`\\phi \\colon \\mathcal{X} \\to \\mathcal{Z}` maps each object :math:`y` to an
+            :math:`m`-dimensional embedding space :math:`\\mathcal{Z} \\subseteq \\mathbb{R}^m`.
             Training complexity is quadratic in the number of objects and prediction complexity is only linear.
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x \in Q}  \;  U (x, \\mu_{C(x)})
+                dc(Q) := \\operatorname{argmax}_{x \\in Q}  \\;  U (x, \\mu_{C(x)})
 
             Parameters
             ----------

--- a/csrank/choicefunction/feta_choice.py
+++ b/csrank/choicefunction/feta_choice.py
@@ -25,19 +25,19 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
         """
             Create a FETA-network architecture for learning choice functions.
             The first-evaluate-then-aggregate approach approximates the context-dependent utility function using the
-            first-order utility function :math:`U_1 \colon \mathcal{X} \\times \mathcal{X} \\rightarrow [0,1]`
-            and zeroth-order utility function  :math:`U_0 \colon \mathcal{X} \\rightarrow [0,1]`.
+            first-order utility function :math:`U_1 \\colon \\mathcal{X} \\times \\mathcal{X} \\rightarrow [0,1]`
+            and zeroth-order utility function  :math:`U_0 \\colon \\mathcal{X} \\rightarrow [0,1]`.
             The scores each object :math:`x` using a context-dependent utility function :math:`U (x, C_i)`:
 
             .. math::
-                 U(x_i, C_i) = U_0(x_i) + \\frac{1}{n-1} \sum_{x_j \in Q \\setminus \{x_i\}} U_1(x_i , x_j) \, .
+                 U(x_i, C_i) = U_0(x_i) + \\frac{1}{n-1} \\sum_{x_j \\in Q \\setminus \\{x_i\\}} U_1(x_i , x_j) \\, .
 
             Training and prediction complexity is quadratic in the number of objects.
             The choice set is defined as:
 
             .. math::
 
-                c(Q) = \{ x_i \in Q \lvert \, U (x_i, C_i) > t \}
+                c(Q) = \\{ x_i \\in Q \\lvert \\, U (x_i, C_i) > t \\}
 
             Parameters
             ----------
@@ -110,11 +110,11 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
         """
             Construct the :math:`1`-st order and :math:`0`-th order models, which are used to approximate the
             :math:`U_1(x, C(x))` and the :math:`U_0(x)` utilities respectively. For each pair of objects in
-            :math:`x_i, x_j \in Q` :math:`U_1(x, C(x))` we construct :class:`CmpNetCore` with weight sharing to
+            :math:`x_i, x_j \\in Q` :math:`U_1(x, C(x))` we construct :class:`CmpNetCore` with weight sharing to
             approximate a pairwise-matrix. A pairwise matrix with index (i,j) corresponds to the :math:`U_1(x_i,x_j)`
             is a measure of how favorable it is to choose :math:`x_i` over :math:`x_j`. Using this matrix we calculate
             the borda score for each object to calculate :math:`U_1(x, C(x))`. For `0`-th order model we construct
-            :math:`\lvert Q \lvert` sequential networks whose weights are shared to evaluate the :math:`U_0(x)` for
+            :math:`\\lvert Q \\lvert` sequential networks whose weights are shared to evaluate the :math:`U_0(x)` for
             each object in the query set :math:`Q`. The output mode is using sigmoid activation.
 
             Returns

--- a/csrank/choicefunction/fetalinear_choice.py
+++ b/csrank/choicefunction/fetalinear_choice.py
@@ -21,14 +21,14 @@ class FETALinearChoiceFunction(FETALinearCore, ChoiceFunctions):
             .. math::
                 \\mu_{C(x)} = \\frac{1}{\\lvert C(x) \\lvert} \\sum_{y \\in C(x)} \\phi(y)
 
-            where :math:`\phi \colon \mathcal{X} \\to \mathcal{Z}` maps each object :math:`y` to an
-            :math:`m`-dimensional embedding space :math:`\mathcal{Z} \subseteq \mathbb{R}^m`.
+            where :math:`\\phi \\colon \\mathcal{X} \\to \\mathcal{Z}` maps each object :math:`y` to an
+            :math:`m`-dimensional embedding space :math:`\\mathcal{Z} \\subseteq \\mathbb{R}^m`.
             Training complexity is quadratic in the number of objects and prediction complexity is only linear.
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x \in Q}  \;  U (x, \\mu_{C(x)})
+                dc(Q) := \\operatorname{argmax}_{x \\in Q}  \\;  U (x, \\mu_{C(x)})
 
             Parameters
             ----------

--- a/csrank/choicefunction/generalized_linear_model.py
+++ b/csrank/choicefunction/generalized_linear_model.py
@@ -21,7 +21,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
         """
             Create an instance of the GeneralizedLinearModel model for learning the choice function. This model is
             adapted from the multinomial logit model :class:`csrank.discretechoice.multinomial_logit_model.MultinomialLogitModel`.
-            The utility score for each object in query set :math:`Q` is defined as :math:`U(x) = w \cdot x`,
+            The utility score for each object in query set :math:`Q` is defined as :math:`U(x) = w \\cdot x`,
             where :math:`w` is the weight vector. The probability of choosing an object :math:`x_i` is defined by taking
             sigmoid over the utility scores:
 
@@ -33,7 +33,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
 
             .. math::
 
-                c(Q) = \{ x_i \in Q \lvert \, P(x_i \\lvert Q) > t \}
+                c(Q) = \\{ x_i \\in Q \\lvert \\, P(x_i \\lvert Q) > t \\}
 
             Parameters
             ----------
@@ -78,17 +78,17 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{b}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{b}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
 
             For ``l2`` regularization the priors are:
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{sd}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{sd}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
         """
         if self.regularization == 'l2':
             weight = pm.Normal
@@ -103,9 +103,9 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
 
     def construct_model(self, X, Y):
         """
-            Constructs the linear logit model which evaluated the utility score as :math:`U(x) = w \cdot x`, where
+            Constructs the linear logit model which evaluated the utility score as :math:`U(x) = w \\cdot x`, where
             :math:`w` is the weight vector. The probability of choosing the object :math:`x_i` from the query set
-            :math:`Q = \{x_1, \ldots ,x_n\}` is:
+            :math:`Q = \\{x_1, \\ldots ,x_n\\}` is:
 
             .. math::
 
@@ -142,11 +142,11 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
         """
             Fit a generalized logit model on the provided set of queries X and choices Y of those objects. The
             provided queries and corresponding preferences are of a fixed size (numpy arrays). For learning this network
-            the binary cross entropy loss function for each object :math:`x_i \in Q` is defined as:
+            the binary cross entropy loss function for each object :math:`x_i \\in Q` is defined as:
 
             .. math::
 
-                C_{i} =  -y(i)\log(P_i) - (1 - y(i))\log(1 - P_i) \enspace,
+                C_{i} =  -y(i)\\log(P_i) - (1 - y(i))\\log(1 - P_i) \\enspace,
 
             where :math:`y` is ground-truth choice vector of the objects in the given query set :math:`Q`.
             The value :math:`y(i) = 1` if object :math:`x_i` is chosen else :math:`y(i) = 0`.

--- a/csrank/choicefunction/pairwise_choice.py
+++ b/csrank/choicefunction/pairwise_choice.py
@@ -12,13 +12,13 @@ class PairwiseSVMChoiceFunction(PairwiseSVM, ChoiceFunctions):
                  fit_intercept=True, random_state=None, **kwargs):
         """
             Create an instance of the :class:`PairwiseSVM` model for learning a choice function.
-            It learns a linear deterministic utility function of the form :math:`U(x) = w \cdot x`, where :math:`w` is
+            It learns a linear deterministic utility function of the form :math:`U(x) = w \\cdot x`, where :math:`w` is
             the weight vector. It is estimated using *pairwise preferences* generated from the choices.
             The choice set is defined as:
 
             .. math::
 
-                c(Q) = \{ x_i \in Q \lvert \, U(x_i) > t \}
+                c(Q) = \\{ x_i \\in Q \\lvert \\, U(x_i) > t \\}
 
             Parameters
             ----------

--- a/csrank/choicefunction/ranknet_choice.py
+++ b/csrank/choicefunction/ranknet_choice.py
@@ -18,13 +18,13 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
             Create an instance of the :class:`RankNetCore` architecture for learning a object ranking function.
             It breaks the preferences into pairwise comparisons and learns a latent utility model for the objects.
             This network learns a latent utility score for each object in the given query set
-            :math:`Q = \{x_1, \ldots ,x_n\}` using the equation :math:`U(x) = F(x, w)` where :math:`w` is the weight
+            :math:`Q = \\{x_1, \\ldots ,x_n\\}` using the equation :math:`U(x) = F(x, w)` where :math:`w` is the weight
             vector. It is estimated using *pairwise preferences* generated from the choices.
             The choice set is defined as:
 
             .. math::
 
-                c(Q) = \{ x_i \in Q \lvert \, U(x_i) > t \}
+                c(Q) = \\{ x_i \\in Q \\lvert \\, U(x_i) > t \\}
 
             Parameters
             ----------
@@ -91,14 +91,14 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
         """
             Fit RankNet model for learning choice function on a provided set of queries. The provided queries can be of 
             a fixed size (numpy arrays). For learning this network the binary cross entropy loss function for a pair of
-            objects :math:`x_i, x_j \in Q` is defined as:
+            objects :math:`x_i, x_j \\in Q` is defined as:
 
             .. math::
 
-                C_{ij} =  -\\tilde{P_{ij}}\log(P_{ij}) - (1 - \\tilde{P_{ij}})\log(1 - P{ij}) \enspace,
+                C_{ij} =  -\\tilde{P_{ij}}\\log(P_{ij}) - (1 - \\tilde{P_{ij}})\\log(1 - P{ij}) \\enspace,
 
             where :math:`\\tilde{P_{ij}}` is ground truth probability of the preference of :math:`x_i` over :math:`x_j`.
-            :math:`\\tilde{P_{ij}} = 1` if :math:`x_i \succ x_j` else :math:`\\tilde{P_{ij}} = 0`.
+            :math:`\\tilde{P_{ij}} = 1` if :math:`x_i \\succ x_j` else :math:`\\tilde{P_{ij}} = 0`.
 
             Parameters
             ----------

--- a/csrank/choicefunction/util.py
+++ b/csrank/choicefunction/util.py
@@ -80,15 +80,15 @@ def categorical_hinge(p, y_true):
 
 
 class BinaryCrossEntropyLikelihood(Discrete):
-    R"""
+    """
     Categorical log-likelihood.
 
     The most general discrete distribution.
 
-    .. math:: f(x \mid p) = p_x
+    .. math:: f(x \\mid p) = p_x
 
     ========  ===================================
-    Support   :math:`x \in \{0, 1, \ldots, |p|-1\}`
+    Support   :math:`x \\in \\{0, 1, \\ldots, |p|-1\\}`
     ========  ===================================
 
     Parameters

--- a/csrank/core/cmpnet_core.py
+++ b/csrank/core/cmpnet_core.py
@@ -68,7 +68,7 @@ class CmpNetCore(Learner):
     def construct_model(self):
         """
             Construct the CmpNet which is used to approximate the :math:`U_1(x_i,x_j)`. For each pair of objects in
-            :math:`x_i, x_j \in Q` we construct two sub-networks with weight sharing in all hidden layers.
+            :math:`x_i, x_j \\in Q` we construct two sub-networks with weight sharing in all hidden layers.
             The output of these networks are connected to two sigmoid units that produces the outputs of the network,
             i.e., :math:`U(x_1,x_2), U(x_2,x_1)` for each pair of objects are evaluated. :math:`U(x_1,x_2)` is a measure
             of how favorable it is to choose :math:`x_1` over :math:`x_2`.
@@ -98,14 +98,14 @@ class CmpNetCore(Learner):
             Fit a generic preference learning CmptNet on the provided set of queries X and preferences Y of those
             objects. The provided queries and corresponding preferences are of a fixed size (numpy arrays).
             For learning this network the binary cross entropy loss function for a pair of objects
-            :math:`x_i, x_j \in Q` is defined as:
+            :math:`x_i, x_j \\in Q` is defined as:
 
             .. math::
 
-                C_{ij} =  -\\tilde{P_{ij}}(0)\\cdot \log(U(x_i,x_j)) - \\tilde{P_{ij}}(1) \\cdot \log(U(x_j,x_i)) \ ,
+                C_{ij} =  -\\tilde{P_{ij}}(0)\\cdot \\log(U(x_i,x_j)) - \\tilde{P_{ij}}(1) \\cdot \\log(U(x_j,x_i)) \\ ,
 
             where :math:`\\tilde{P_{ij}}` is ground truth probability of the preference of :math:`x_i` over :math:`x_j`.
-            :math:`\\tilde{P_{ij}} = (1,0)` if :math:`x_i \succ x_j` else :math:`\\tilde{P_{ij}} = (0,1)`.
+            :math:`\\tilde{P_{ij}} = (1,0)` if :math:`x_i \\succ x_j` else :math:`\\tilde{P_{ij}} = (0,1)`.
 
             Parameters
             ----------

--- a/csrank/core/fate_network.py
+++ b/csrank/core/fate_network.py
@@ -328,7 +328,7 @@ class FATENetwork(FATENetworkCore):
             set :math:`Q` of size (n_objects, n_features),iterate over it for each object and concatenate the
             context-representation feature tensor of size :math:`\\lvert  \\mu_{C(x)} \\lvert` into a joint layers.
             So, for each object we share the weights in the joint network and the output of this network is used to
-            learn the generalized latent utility score :math:`U (x, \\mu_{C(x)})` of each object :math:`x \in Q`.
+            learn the generalized latent utility score :math:`U (x, \\mu_{C(x)})` of each object :math:`x \\in Q`.
 
             Parameters
             ----------

--- a/csrank/core/feta_network.py
+++ b/csrank/core/feta_network.py
@@ -152,11 +152,11 @@ class FETANetwork(Learner):
         """
             Construct the :math:`1`-st order and :math:`0`-th order models, which are used to approximate the
             :math:`U_1(x, C(x))` and the :math:`U_0(x)` utilities respectively. For each pair of objects in
-            :math:`x_i, x_j \in Q` :math:`U_1(x, C(x))` we construct :class:`CmpNetCore` with weight sharing to
+            :math:`x_i, x_j \\in Q` :math:`U_1(x, C(x))` we construct :class:`CmpNetCore` with weight sharing to
             approximate a pairwise-matrix. A pairwise matrix with index (i,j) corresponds to the :math:`U_1(x_i,x_j)`
             is a measure of how favorable it is to choose :math:`x_i` over :math:`x_j`. Using this matrix we calculate
             the borda score for each object to calculate :math:`U_1(x, C(x))`. For `0`-th order model we construct
-            :math:`\lvert Q \lvert` sequential networks whose weights are shared to evaluate the :math:`U_0(x)` for
+            :math:`\\lvert Q \\lvert` sequential networks whose weights are shared to evaluate the :math:`U_0(x)` for
             each object in the query set :math:`Q`. The output mode is using linear activation.
 
             Returns

--- a/csrank/core/ranknet_core.py
+++ b/csrank/core/ranknet_core.py
@@ -61,7 +61,7 @@ class RankNetCore(Learner):
     def construct_model(self):
         """
             Construct the RankNet which is used to approximate the :math:`U(x)` utility. For each pair of objects in
-            :math:`x_i, x_j \in Q` we construct two sub-networks with weight sharing in all hidden layer apart form the
+            :math:`x_i, x_j \\in Q` we construct two sub-networks with weight sharing in all hidden layer apart form the
             last layer for which weights are mirrored version of each other. The output of these networks are connected
             to a sigmoid unit that produces the output :math:`P_{ij}` which is the probability of preferring object
             :math:`x_i` over :math:`x_j`, to approximate the :math:`U(x)`.
@@ -91,14 +91,14 @@ class RankNetCore(Learner):
         """
             Fit a generic preference learning RankNet model on a provided set of queries. The provided queries can be of
             a fixed size (numpy arrays). For learning this network the binary cross entropy loss function for a pair of
-            objects :math:`x_i, x_j \in Q` is defined as:
+            objects :math:`x_i, x_j \\in Q` is defined as:
 
             .. math::
 
-                C_{ij} =  -\\tilde{P_{ij}}\log(P_{ij}) - (1 - \\tilde{P_{ij}})\log(1 - P{ij}) \enspace,
+                C_{ij} =  -\\tilde{P_{ij}}\\log(P_{ij}) - (1 - \\tilde{P_{ij}})\\log(1 - P{ij}) \\enspace,
 
             where :math:`\\tilde{P_{ij}}` is ground truth probability of the preference of :math:`x_i` over :math:`x_j`.
-            :math:`\\tilde{P_{ij}} = 1` if :math:`x_i \succ x_j` else :math:`\\tilde{P_{ij}} = 0`.
+            :math:`\\tilde{P_{ij}} = 1` if :math:`x_i \\succ x_j` else :math:`\\tilde{P_{ij}} = 0`.
 
             Parameters
             ----------

--- a/csrank/dataset_reader/objectranking/depth_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/depth_dataset_reader.py
@@ -159,7 +159,7 @@ def load_dataset(filename):
                 instances[qid] = []
                 if '#' in arr:
                     arr = arr[:-2]
-            features = [float(re.search('\:([0-9\.]*)', x).group(1)) for x in arr[2:]]
+            features = [float(re.search(r'\:([0-9\.]*)', x).group(1)) for x in arr[2:]]
             instances[qid].append(Instance(depth, features))
     n_instances = len(instances)
     n_objects = len(instances[1])

--- a/csrank/dataset_reader/objectranking/util.py
+++ b/csrank/dataset_reader/objectranking/util.py
@@ -32,8 +32,8 @@ def generate_pairwise_instances(features):
 def generate_complete_pairwise_dataset(X, Y):
     """
         Generates the pairiwse preference data from the given rankings.The ranking amongst the objects in a query set
-        :math:`Q = \{x_1, x_2, x_3\}` is represented by :math:`\pi = (2,1,3)`, such that :math:`\pi(2)=1` is the position of the :math:`x_2`.
-        One can extract the following *pairwise preferences* :math:`x_2 \succ x_1, x_2 \succ x_3 and x_1 \succ x_3`.
+        :math:`Q = \\{x_1, x_2, x_3\\}` is represented by :math:`\\pi = (2,1,3)`, such that :math:`\\pi(2)=1` is the position of the :math:`x_2`.
+        One can extract the following *pairwise preferences* :math:`x_2 \\succ x_1, x_2 \\succ x_3 and x_1 \\succ x_3`.
         This function generates pairwise preferences which can be used to learn different :class:`ObjectRanker` as:
             1. :class:`RankNet`
             2. :class:`CmpNet`
@@ -49,24 +49,24 @@ def generate_complete_pairwise_dataset(X, Y):
         Returns
         -------
         x_train: array-like, shape (n_samples, n_features)
-            The difference vector between the two objects with pairwise preference :math:`x_2 \succ x_1`, i.e.
-            :math:`x_2-x_1` with n_samples=:math:`n_{instances} \cdot (n_{objects} \\choose 2)`. :class:`RankSVM` uses
+            The difference vector between the two objects with pairwise preference :math:`x_2 \\succ x_1`, i.e.
+            :math:`x_2-x_1` with n_samples=:math:`n_{instances} \\cdot (n_{objects} \\choose 2)`. :class:`RankSVM` uses
             it as input.
         x_train1: array-like, shape (n_samples, n_features)
-            The first object :math:`x_2` of the pairwise preference :math:`x_2 \succ x_1`, with
-            n_samples=:math:`n_{instances} \cdot (n_{objects} \\choose 2)`. :class:`RankNet` and :class:`CmpNet` uses it
+            The first object :math:`x_2` of the pairwise preference :math:`x_2 \\succ x_1`, with
+            n_samples=:math:`n_{instances} \\cdot (n_{objects} \\choose 2)`. :class:`RankNet` and :class:`CmpNet` uses it
             as input.
         x_train2: array-like, shape (n_samples, n_features)
-            The second object :math:`x_1` of the pairwise preference :math:`x_2 \succ x_1`, with
-            n_samples=:math:`n_{instances} \cdot (n_{objects} \\choose 2)`. :class:`RankNet` and :class:`CmpNet` uses it
+            The second object :math:`x_1` of the pairwise preference :math:`x_2 \\succ x_1`, with
+            n_samples=:math:`n_{instances} \\cdot (n_{objects} \\choose 2)`. :class:`RankNet` and :class:`CmpNet` uses it
             as input.
         y_double: array-like, shape (n_samples, 2)
-            The preference :math:`x_2 \succ x_1` between the objects :math:`x_2` and :math:`x_1`, i.e. (1,0)
-            with n_samples=:math:`n_{instances} \cdot (n_{objects} \\choose 2)`. :class:`CmpNet` uses it
+            The preference :math:`x_2 \\succ x_1` between the objects :math:`x_2` and :math:`x_1`, i.e. (1,0)
+            with n_samples=:math:`n_{instances} \\cdot (n_{objects} \\choose 2)`. :class:`CmpNet` uses it
             as input.
         y_double: array-like, shape (n_samples)
-            The preference :math:`x_2 \succ x_1` between the objects :math:`x_2` and :math:`x_1`, i.e. 1
-            with n_samples=:math:`n_{instances} \cdot (n_{objects} \\choose 2)`.:class:`RankNet` and :class:`RankSVM`
+            The preference :math:`x_2 \\succ x_1` between the objects :math:`x_2` and :math:`x_1`, i.e. 1
+            with n_samples=:math:`n_{instances} \\cdot (n_{objects} \\choose 2)`.:class:`RankNet` and :class:`RankSVM`
             uses it as output.
     """
     try:

--- a/csrank/discretechoice/cmpnet_discrete_choice.py
+++ b/csrank/discretechoice/cmpnet_discrete_choice.py
@@ -20,17 +20,17 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
             objects and the pairwise predicate is evaluated using them. The outputs of the network for each pair of
             objects :math:`U(x_1,x_2), U(x_2,x_1)` are evaluated.
             :math:`U(x_1,x_2)` is a measure of how favorable it is to choose :math:`x_1` over :math:`x_2`.
-            The utility score of object :math:`x_i` in query set :math:`Q = \{ x_1 , \ldots , x_n \}` is evaluated as:
+            The utility score of object :math:`x_i` in query set :math:`Q = \\{ x_1 , \\ldots , x_n \\}` is evaluated as:
 
             .. math::
 
-                U(x_i) = \left\{ \\frac{1}{n-1} \sum_{j \in [n] \setminus \{i\}} U_1(x_i , x_j)\\right\}
+                U(x_i) = \\left\\{ \\frac{1}{n-1} \\sum_{j \\in [n] \\setminus \\{i\\}} U_1(x_i , x_j)\\right\\}
 
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{i \in [n]}  \; U(x_i)
+                dc(Q) := \\operatorname{argmax}_{i \\in [n]}  \\; U(x_i)
 
             Parameters
             ----------

--- a/csrank/discretechoice/discrete_choice.py
+++ b/csrank/discretechoice/discrete_choice.py
@@ -16,7 +16,7 @@ class DiscreteObjectChooser(metaclass=ABCMeta):
         """
             Binary discrete choice vector :math:`y` represents the choices amongst the objects in :math:`Q`, such that
             :math:`y(k) = 1` represents that the object :math:`x_k` is chosen and :math:`y(k) = 0` represents
-            it is not chosen. For choice to be discrete :math:`\sum_{x_i \in Q} y(i) = 1`. Predict discrete choices for
+            it is not chosen. For choice to be discrete :math:`\\sum_{x_i \\in Q} y(i) = 1`. Predict discrete choices for
             the scores for a given collection of sets of objects (query sets).
 
             Parameters

--- a/csrank/discretechoice/fate_discrete_choice.py
+++ b/csrank/discretechoice/fate_discrete_choice.py
@@ -25,14 +25,14 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
             .. math::
                 \\mu_{C(x)} = \\frac{1}{\\lvert C(x) \\lvert} \\sum_{y \\in C(x)} \\phi(y)
 
-            where :math:`\phi \colon \mathcal{X} \\to \mathcal{Z}` maps each object :math:`y` to an
-            :math:`m`-dimensional embedding space :math:`\mathcal{Z} \subseteq \mathbb{R}^m`.
+            where :math:`\\phi \\colon \\mathcal{X} \\to \\mathcal{Z}` maps each object :math:`y` to an
+            :math:`m`-dimensional embedding space :math:`\\mathcal{Z} \\subseteq \\mathbb{R}^m`.
             Training complexity is quadratic in the number of objects and prediction complexity is only linear.
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x \in Q}  \;  U (x, \\mu_{C(x)})
+                dc(Q) := \\operatorname{argmax}_{x \\in Q}  \\;  U (x, \\mu_{C(x)})
 
             Parameters
             ----------

--- a/csrank/discretechoice/fatelinear_discrete_choice.py
+++ b/csrank/discretechoice/fatelinear_discrete_choice.py
@@ -20,14 +20,14 @@ class FATELinearDiscreteChoiceFunction(FATELinearCore, DiscreteObjectChooser):
             .. math::
                 \\mu_{C(x)} = \\frac{1}{\\lvert C(x) \\lvert} \\sum_{y \\in C(x)} \\phi(y)
 
-            where :math:`\phi \colon \mathcal{X} \\to \mathcal{Z}` maps each object :math:`y` to an
-            :math:`m`-dimensional embedding space :math:`\mathcal{Z} \subseteq \mathbb{R}^m`.
+            where :math:`\\phi \\colon \\mathcal{X} \\to \\mathcal{Z}` maps each object :math:`y` to an
+            :math:`m`-dimensional embedding space :math:`\\mathcal{Z} \\subseteq \\mathbb{R}^m`.
             Training complexity is quadratic in the number of objects and prediction complexity is only linear.
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x \in Q}  \;  U (x, \\mu_{C(x)})
+                dc(Q) := \\operatorname{argmax}_{x \\in Q}  \\;  U (x, \\mu_{C(x)})
 
             Parameters
             ----------

--- a/csrank/discretechoice/feta_discrete_choice.py
+++ b/csrank/discretechoice/feta_discrete_choice.py
@@ -24,19 +24,19 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
         """
             Create a FETA-network architecture for learning the discrete choice functions.
             The first-evaluate-then-aggregate approach approximates the context-dependent utility function using the
-            first-order utility function :math:`U_1 \colon \mathcal{X} \\times \mathcal{X} \\rightarrow [0,1]`
-            and zeroth-order utility function  :math:`U_0 \colon \mathcal{X} \\rightarrow [0,1]`.
+            first-order utility function :math:`U_1 \\colon \\mathcal{X} \\times \\mathcal{X} \\rightarrow [0,1]`
+            and zeroth-order utility function  :math:`U_0 \\colon \\mathcal{X} \\rightarrow [0,1]`.
             The scores each object :math:`x` using a context-dependent utility function :math:`U (x, C_i)`:
 
             .. math::
-                 U(x_i, C_i) = U_0(x_i) + \\frac{1}{n-1} \sum_{x_j \in Q \\setminus \{x_i\}} U_1(x_i , x_j) \, .
+                 U(x_i, C_i) = U_0(x_i) + \\frac{1}{n-1} \\sum_{x_j \\in Q \\setminus \\{x_i\\}} U_1(x_i , x_j) \\, .
 
             Training and prediction complexity is quadratic in the number of objects.
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x_i \in Q}  \;  U (x_i, C_i)
+                dc(Q) := \\operatorname{argmax}_{x_i \\in Q}  \\;  U (x_i, C_i)
 
             Parameters
             ----------
@@ -111,11 +111,11 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
         """
             Construct the :math:`1`-st order and :math:`0`-th order models, which are used to approximate the
             :math:`U_1(x, C(x))` and the :math:`U_0(x)` utilities respectively. For each pair of objects in
-            :math:`x_i, x_j \in Q` :math:`U_1(x, C(x))` we construct :class:`CmpNetCore` with weight sharing to
+            :math:`x_i, x_j \\in Q` :math:`U_1(x, C(x))` we construct :class:`CmpNetCore` with weight sharing to
             approximate a pairwise-matrix. A pairwise matrix with index (i,j) corresponds to the :math:`U_1(x_i,x_j)`
             is a measure of how favorable it is to choose :math:`x_i` over :math:`x_j`. Using this matrix we calculate
             the borda score for each object to calculate :math:`U_1(x, C(x))`. For `0`-th order model we construct
-            :math:`\lvert Q \lvert` sequential networks whose weights are shared to evaluate the :math:`U_0(x)` for
+            :math:`\\lvert Q \\lvert` sequential networks whose weights are shared to evaluate the :math:`U_0(x)` for
             each object in the query set :math:`Q`. The output mode is using sigmoid activation.
 
             Returns

--- a/csrank/discretechoice/fetalinear_discrete_choice.py
+++ b/csrank/discretechoice/fetalinear_discrete_choice.py
@@ -20,14 +20,14 @@ class FETALinearDiscreteChoiceFunction(FETALinearCore, DiscreteObjectChooser):
             .. math::
                 \\mu_{C(x)} = \\frac{1}{\\lvert C(x) \\lvert} \\sum_{y \\in C(x)} \\phi(y)
 
-            where :math:`\phi \colon \mathcal{X} \\to \mathcal{Z}` maps each object :math:`y` to an
-            :math:`m`-dimensional embedding space :math:`\mathcal{Z} \subseteq \mathbb{R}^m`.
+            where :math:`\\phi \\colon \\mathcal{X} \\to \\mathcal{Z}` maps each object :math:`y` to an
+            :math:`m`-dimensional embedding space :math:`\\mathcal{Z} \\subseteq \\mathbb{R}^m`.
             Training complexity is quadratic in the number of objects and prediction complexity is only linear.
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x \in Q}  \;  U (x, \\mu_{C(x)})
+                dc(Q) := \\operatorname{argmax}_{x \\in Q}  \\;  U (x, \\mu_{C(x)})
 
             Parameters
             ----------

--- a/csrank/discretechoice/generalized_nested_logit.py
+++ b/csrank/discretechoice/generalized_nested_logit.py
@@ -22,21 +22,21 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
         """
             Create an instance of the Generalized Nested Logit model for learning the discrete choice function. This
             model divides objects into subsets called nests, such that the each object is associtated to each nest to some degree.
-            This model structure is 1-layer of hierarchy and the :math:`\lambda` for each nest :math:`B_k` signifies the degree of independence
-            and  :math:`1-\lambda` signifies the correlations between the object in it. We learn two weight vectors and the  :math:`\lambda s`.
+            This model structure is 1-layer of hierarchy and the :math:`\\lambda` for each nest :math:`B_k` signifies the degree of independence
+            and  :math:`1-\\lambda` signifies the correlations between the object in it. We learn two weight vectors and the  :math:`\\lambda s`.
             The probability of choosing an object :math:`x_i` from the given query set :math:`Q` is defined by product
             of choosing the nest in which :math:`x_i` exists and then choosing the the object from the nest.
 
             .. math::
 
-                P(x_i \\lvert Q) = P_i = \sum_{\substack{B_k \in \mathcal{B} \\ i \in B_k}}P_{i \\lvert B_k} P_{B_k} \enspace ,
+                P(x_i \\lvert Q) = P_i = \\sum_{\\substack{B_k \\in \\mathcal{B} \\ i \\in B_k}}P_{i \\lvert B_k} P_{B_k} \\enspace ,
 
 
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x_i \in Q }  \; P(x_i \\lvert Q)
+                dc(Q) := \\operatorname{argmax}_{x_i \\in Q }  \\; P(x_i \\lvert Q)
 
             Parameters
             ----------
@@ -104,17 +104,17 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{b}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{b}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
 
             For ``l2`` regularization the priors are:
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{sd}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{sd}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
 
             Returns
             -------
@@ -138,23 +138,23 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
         """
             This method calculates the probability of choosing an object from the query set using the following parameters of the model which are used:
 
-                * **weights** (:math:`w`): Weights to get the utility of the object :math:`Y_i = U(x_i) = w \cdot x_i`
-                * **weights_k** (:math:`w_k`): Weights to get fractional allocation of each object :math:'x_j'  in :math:'Q' to each nest math:`B_k` as :math:`\alpha_{ik} = w_k \cdot x_i`.
-                * **lambda_k** (:math:`\lambda_k`): Lambda for nest :math:`B_k` for correlations between the obejcts.
+                * **weights** (:math:`w`): Weights to get the utility of the object :math:`Y_i = U(x_i) = w \\cdot x_i`
+                * **weights_k** (:math:`w_k`): Weights to get fractional allocation of each object :math:'x_j'  in :math:'Q' to each nest math:`B_k` as :math:`\\alpha_{ik} = w_k \\cdot x_i`.
+                * **lambda_k** (:math:`\\lambda_k`): Lambda for nest :math:`B_k` for correlations between the obejcts.
 
             The probability of choosing the object :math:`x_i` from the query set :math:`Q`:
 
             .. math::
-                P_i = \sum_{\substack{B_k \in \mathcal{B} \\ i \in B_k}} P_{i \\lvert {B_k}} P_{B_k} \enspace where, \\\\
-                P_{B_k} = \\frac{{\\left(\sum_{j \in B_k} {\\left(\\alpha_{jk} \\boldsymbol{e}^{V_j} \\right)}^ {^{1}/{\lambda_k}} \\right)}^{\lambda_k}}{\sum_{\ell = 1}^{K} {\\left( \sum_{j \in B_{\ell}} {\\left( \\alpha_{j\ell} \\boldsymbol{e}^{V_j} \\right)}^{^{1}/{\lambda_\ell}} \\right)^{\lambda_{\ell}}}} \\\\
-                P_{{i} \\lvert {B_k}} = \\frac{{\\left(\\alpha_{ik} \\boldsymbol{e}^{V_i} \\right)}^{^{1}/{\lambda_k}}}{\sum_{j \in B_k} {\\left(\\alpha_{jk} \\boldsymbol{e}^{V_j} \\right)}^{^{1}/{\lambda_k}}} \enspace ,
+                P_i = \\sum_{\\substack{B_k \\in \\mathcal{B} \\ i \\in B_k}} P_{i \\lvert {B_k}} P_{B_k} \\enspace where, \\\\
+                P_{B_k} = \\frac{{\\left(\\sum_{j \\in B_k} {\\left(\\alpha_{jk} \\boldsymbol{e}^{V_j} \\right)}^ {^{1}/{\\lambda_k}} \\right)}^{\\lambda_k}}{\\sum_{\\ell = 1}^{K} {\\left( \\sum_{j \\in B_{\\ell}} {\\left( \\alpha_{j\\ell} \\boldsymbol{e}^{V_j} \\right)}^{^{1}/{\\lambda_\\ell}} \\right)^{\\lambda_{\\ell}}}} \\\\
+                P_{{i} \\lvert {B_k}} = \\frac{{\\left(\\alpha_{ik} \\boldsymbol{e}^{V_i} \\right)}^{^{1}/{\\lambda_k}}}{\\sum_{j \\in B_k} {\\left(\\alpha_{jk} \\boldsymbol{e}^{V_j} \\right)}^{^{1}/{\\lambda_k}}} \\enspace ,
 
 
             Parameters
             ----------
             utility : theano tensor
                 (n_instances, n_objects)
-                Utility :math:`Y_i` of the objects :math:`x_i \in Q` in the query sets
+                Utility :math:`Y_i` of the objects :math:`x_i \\in Q` in the query sets
             lambda_k : theano tensor (range : [alpha, 1.0])
                 (n_nests)
                 Measure of independence amongst the obejcts in each nests
@@ -166,7 +166,7 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
             -------
             p : theano tensor
                 (n_instances, n_objects)
-                Choice probabilities :math:`P_i` of the objects :math:`x_i \in Q` in the query sets
+                Choice probabilities :math:`P_i` of the objects :math:`x_i \\in Q` in the query sets
 
         """
         n_nests = self.n_nests
@@ -203,9 +203,9 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
     def construct_model(self, X, Y):
         """
             Constructs the nested logit model by applying priors on weight vectors **weights** and **weights_k** as per
-            :meth:`model_configuration`. Then we apply a uniform prior to the :math:`\lambda s`, i.e.
-            :math:`\lambda s \sim Uniform(\\text{alpha}, 1.0)`.The probability of choosing the object :math:`x_i` from the
-            query set :math:`Q = \{x_1, \ldots ,x_n\}` is evaluated in :meth:`get_probabilities`.
+            :meth:`model_configuration`. Then we apply a uniform prior to the :math:`\\lambda s`, i.e.
+            :math:`\\lambda s \\sim Uniform(\\text{alpha}, 1.0)`.The probability of choosing the object :math:`x_i` from the
+            query set :math:`Q = \\{x_1, \\ldots ,x_n\\}` is evaluated in :meth:`get_probabilities`.
 
             Parameters
             ----------
@@ -245,11 +245,11 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
         """
             Fit a generalized nested logit model on the provided set of queries X and choices Y of those objects. The
             provided queries and corresponding preferences are of a fixed size (numpy arrays). For learning this network
-            the categorical cross entropy loss function for each object :math:`x_i \in Q` is defined as:
+            the categorical cross entropy loss function for each object :math:`x_i \\in Q` is defined as:
 
             .. math::
 
-                C_{i} =  -y(i)\log(P_i) \enspace,
+                C_{i} =  -y(i)\\log(P_i) \\enspace,
 
             where :math:`y` is ground-truth discrete choice vector of the objects in the given query set :math:`Q`.
             The value :math:`y(i) = 1` if object :math:`x_i` is chosen else :math:`y(i) = 0`.

--- a/csrank/discretechoice/likelihoods.py
+++ b/csrank/discretechoice/likelihoods.py
@@ -33,15 +33,15 @@ likelihood_dict = {'categorical_crossentropy': categorical_crossentropy, 'binary
 
 
 class LogLikelihood(Discrete):
-    R"""
+    """
     Categorical log-likelihood.
 
     The most general discrete distribution.
 
-    .. math:: f(x \mid p) = p_x
+    .. math:: f(x \\mid p) = p_x
 
     ========  ===================================
-    Support   :math:`x \in \{0, 1, \ldots, |p|-1\}`
+    Support   :math:`x \\in \\{0, 1, \\ldots, |p|-1\\}`
     ========  ===================================
 
     Parameters

--- a/csrank/discretechoice/mixed_logit_model.py
+++ b/csrank/discretechoice/mixed_logit_model.py
@@ -21,19 +21,19 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
             Create an instance of the Mixed Logit model for learning the discrete choice function. In this model we
             assume weights of this model to be random due to which this model can learn different variations in choices
             amongst the individuals. The utility score for each object in query set :math:`Q` is defined as
-            :math:`U_r(x) = w_r \cdot x`, where :math:`w_r` is the k-th sample weight vector from the underlying distribution
+            :math:`U_r(x) = w_r \\cdot x`, where :math:`w_r` is the k-th sample weight vector from the underlying distribution
             The probability of choosing an object :math:`x_i` is defined by taking softmax over the
             utility scores of the objects:
 
             .. math::
 
-                P(x_i \\lvert Q) = \\frac{1}{R} \sum_{r=1}^R \\frac{exp(U_r(x_i))}{\sum_{x_j \in Q} exp(U_r(x_j))}
+                P(x_i \\lvert Q) = \\frac{1}{R} \\sum_{r=1}^R \\frac{exp(U_r(x_i))}{\\sum_{x_j \\in Q} exp(U_r(x_j))}
 
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x_i \in Q }  \; P(x_i \\lvert Q)
+                dc(Q) := \\operatorname{argmax}_{x_i \\in Q }  \\; P(x_i \\lvert Q)
 
             Parameters
             ----------
@@ -85,17 +85,17 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{b}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{b}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
 
             For ``l2`` regularization the priors are:
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{sd}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{sd}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
         """
         if self._config is None:
             if self.regularization == 'l2':
@@ -113,11 +113,11 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
         """
             Constructs the mixed logit model by applying priors on weight vectors **weights** as per
             :meth:`model_configuration`. The probability of choosing the object :math:`x_i` from the query set
-            :math:`Q = \{x_1, \ldots ,x_n\}` assuming we draw :math:`R` samples of the weight vectors is:
+            :math:`Q = \\{x_1, \\ldots ,x_n\\}` assuming we draw :math:`R` samples of the weight vectors is:
 
             .. math::
 
-                P(x_i \\lvert Q) = \\frac{1}{R} \sum_{r=1}^R \\frac{exp(U_r(x_i))}{\sum_{x_j \in Q} exp(U_r(x_j))}
+                P(x_i \\lvert Q) = \\frac{1}{R} \\sum_{r=1}^R \\frac{exp(U_r(x_i))}{\\sum_{x_j \\in Q} exp(U_r(x_j))}
 
             Parameters
             ----------
@@ -147,11 +147,11 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
         """
             Fit a mixed logit model on the provided set of queries X and choices Y of those objects. The provided
             queries and corresponding preferences are of a fixed size (numpy arrays). For learning this network
-            the categorical cross entropy loss function for each object :math:`x_i \in Q` is defined as:
+            the categorical cross entropy loss function for each object :math:`x_i \\in Q` is defined as:
 
             .. math::
 
-                C_{i} =  -y(i)\log(P_i) \enspace,
+                C_{i} =  -y(i)\\log(P_i) \\enspace,
 
             where :math:`y` is ground-truth discrete choice vector of the objects in the given query set :math:`Q`.
             The value :math:`y(i) = 1` if object :math:`x_i` is chosen else :math:`y(i) = 0`.

--- a/csrank/discretechoice/multinomial_logit_model.py
+++ b/csrank/discretechoice/multinomial_logit_model.py
@@ -17,19 +17,19 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
     def __init__(self, n_object_features, loss_function='', regularization='l2', **kwargs):
         """
             Create an instance of the Multinomial Logit model for learning the discrete choice function. The utility
-            score for each object in query set :math:`Q` is defined as :math:`U(x) = w \cdot x`, where :math:`w` is
+            score for each object in query set :math:`Q` is defined as :math:`U(x) = w \\cdot x`, where :math:`w` is
             the weight vector. The probability of choosing an object :math:`x_i` is defined by taking softmax over the
             utility scores of the objects:
 
             .. math::
 
-                P(x_i \\lvert Q) = \\frac{exp(U(x_i))}{\sum_{x_j \in Q} exp(U(x_j))}
+                P(x_i \\lvert Q) = \\frac{exp(U(x_i))}{\\sum_{x_j \\in Q} exp(U(x_j))}
 
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x_i \in Q }  \; P(x_i \\lvert Q)
+                dc(Q) := \\operatorname{argmax}_{x_i \\in Q }  \\; P(x_i \\lvert Q)
 
             Parameters
             ----------
@@ -76,17 +76,17 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{b}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{b}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
 
             For ``l2`` regularization the priors are:
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{sd}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{sd}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
         """
         if self._config is None:
             if self.regularization == 'l2':
@@ -102,13 +102,13 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
 
     def construct_model(self, X, Y):
         """
-            Constructs the multinomial logit model which evaluated the utility score as :math:`U(x) = w \cdot x`, where
+            Constructs the multinomial logit model which evaluated the utility score as :math:`U(x) = w \\cdot x`, where
             :math:`w` is the weight vector. The probability of choosing the object :math:`x_i` from the query set
-            :math:`Q = \{x_1, \ldots ,x_n\}` is:
+            :math:`Q = \\{x_1, \\ldots ,x_n\\}` is:
 
             .. math::
 
-                P_i = P(x_i \\lvert Q) = \\frac{exp(U(x_i))}{\sum_{x_j \in Q} exp(U(x_j))}
+                P_i = P(x_i \\lvert Q) = \\frac{exp(U(x_i))}{\\sum_{x_j \\in Q} exp(U(x_j))}
 
             Parameters
             ----------
@@ -142,11 +142,11 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
         """
             Fit a multinomial logit model on the provided set of queries X and choices Y of those objects. The
             provided queries and corresponding preferences are of a fixed size (numpy arrays). For learning this network
-            the categorical cross entropy loss function for each object :math:`x_i \in Q` is defined as:
+            the categorical cross entropy loss function for each object :math:`x_i \\in Q` is defined as:
 
             .. math::
 
-                C_{i} =  -y(i)\log(P_i) \enspace,
+                C_{i} =  -y(i)\\log(P_i) \\enspace,
 
             where :math:`y` is ground-truth discrete choice vector of the objects in the given query set :math:`Q`.
             The value :math:`y(i) = 1` if object :math:`x_i` is chosen else :math:`y(i) = 0`.

--- a/csrank/discretechoice/nested_logit_model.py
+++ b/csrank/discretechoice/nested_logit_model.py
@@ -23,23 +23,23 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
         """
             Create an instance of the Nested Logit model for learning the discrete choice function. This model divides
             objects into disjoint subsets called nests,such that the objects which are similar to each other are in same
-            nest. This model structure is 1-layer of hierarchy and the :math:`\lambda` for each nest :math:`B_k` signifies
-            the degree of independence and  :math:`1-\lambda` signifies the correlations between the object in it. We
-            learn two weight vectors and the  :math:`\lambda s`.
+            nest. This model structure is 1-layer of hierarchy and the :math:`\\lambda` for each nest :math:`B_k` signifies
+            the degree of independence and  :math:`1-\\lambda` signifies the correlations between the object in it. We
+            learn two weight vectors and the  :math:`\\lambda s`.
 
             The probability of choosing an object :math:`x_i` from the given query set :math:`Q` is defined by product
             of choosing the nest in which :math:`x_i` exists and then choosing the the object from the nest.
 
             .. math::
 
-                P(x_i \\lvert Q) = P_i = P_{i \lvert B_k} P_{B_k} \enspace ,
+                P(x_i \\lvert Q) = P_i = P_{i \\lvert B_k} P_{B_k} \\enspace ,
 
 
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x_i \in Q }  \; P(x_i \\lvert Q)
+                dc(Q) := \\operatorname{argmax}_{x_i \\in Q }  \\; P(x_i \\lvert Q)
 
             Parameters
             ----------
@@ -106,17 +106,17 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{b}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{b}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
 
             For ``l2`` regularization the priors are:
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{sd}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{sd}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
 
 
             Returns
@@ -180,34 +180,34 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
         """
             This method calculates the probability of choosing an object from the query set using the following parameters of the model which are used:
 
-                * **weights** (:math:`w`): Weights to get the utility of the object :math:`Y_i = U(x_i) = w \cdot x_i`
-                * **weights_k** (:math:`w_k`): Weights to get the utility of the next  :math:`W_k = U_k(x) = w_k \cdot c_k`, where :math:`c_k` is the center of the object space of nest :math:`B_k`
-                * **lambda_k** (:math:`\lambda_k`): Lambda is the measure of independence amongst the obejcts in the nest :math:`B_k`
+                * **weights** (:math:`w`): Weights to get the utility of the object :math:`Y_i = U(x_i) = w \\cdot x_i`
+                * **weights_k** (:math:`w_k`): Weights to get the utility of the next  :math:`W_k = U_k(x) = w_k \\cdot c_k`, where :math:`c_k` is the center of the object space of nest :math:`B_k`
+                * **lambda_k** (:math:`\\lambda_k`): Lambda is the measure of independence amongst the obejcts in the nest :math:`B_k`
 
             The probability of choosing the object  :math:`x_i` from the query set :math:`Q`:
 
             .. math::
-                P_i = \\frac{\\boldsymbol{e}^{ ^{Y_i} /_{\lambda_k}}}{\sum_{j \in B_k} \\boldsymbol{e}^{^{Y_j} /_{\lambda_k}}} \\frac {\\boldsymbol{e}^{W_k + \lambda_k I_k}} {\sum_{\\ell = 1}^{K} \\boldsymbol{e}^{ W_{\\ell } + \lambda_{\\ell} I_{\\ell}}} \quad i \in B_k  \enspace , \\\\
-                where,\enspace I_k = \ln \sum_{ j \in B_k} \\boldsymbol{e}^{^{Y_j} /_{\lambda_k}}
+                P_i = \\frac{\\boldsymbol{e}^{ ^{Y_i} /_{\\lambda_k}}}{\\sum_{j \\in B_k} \\boldsymbol{e}^{^{Y_j} /_{\\lambda_k}}} \\frac {\\boldsymbol{e}^{W_k + \\lambda_k I_k}} {\\sum_{\\ell = 1}^{K} \\boldsymbol{e}^{ W_{\\ell } + \\lambda_{\\ell} I_{\\ell}}} \\quad i \\in B_k  \\enspace , \\\\
+                where,\\enspace I_k = \\ln \\sum_{ j \\in B_k} \\boldsymbol{e}^{^{Y_j} /_{\\lambda_k}}
 
 
             Parameters
             ----------
             utility : theano tensor
                 (n_instances, n_objects)
-                Utility :math:`Y_i` of the objects :math:`x_i \in Q` in the query sets
+                Utility :math:`Y_i` of the objects :math:`x_i \\in Q` in the query sets
             lambda_k : theano tensor (range : [alpha, 1.0])
                 (n_nests)
                 Measure of independence amongst the obejcts in each nests
             utility_k : theano tensor
                 (n_instances, n_nests)
-                Utilities of the nests :math:`B_k \in \mathcal{B}`
+                Utilities of the nests :math:`B_k \\in \\mathcal{B}`
 
             Returns
             -------
             p : theano tensor
                 (n_instances, n_objects)
-                Choice probabilities :math:`P_i` of the objects :math:`x_i \in Q` in the query sets
+                Choice probabilities :math:`P_i` of the objects :math:`x_i \\in Q` in the query sets
 
         """
         n_instances, n_objects = self.y_nests.shape
@@ -258,9 +258,9 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
     def construct_model(self, X, Y):
         """
             Constructs the nested logit model by applying priors on weight vectors **weights** and **weights_k** as per
-            :meth:`model_configuration`. Then we apply a uniform prior to the :math:`\lambda s`, i.e.
-            :math:`\lambda s \sim Uniform(\\text{alpha}, 1.0)`.The probability of choosing the object :math:`x_i` from
-            the query set :math:`Q = \{x_1, \ldots ,x_n\}` is evaluated in :meth:`get_probabilities`.
+            :meth:`model_configuration`. Then we apply a uniform prior to the :math:`\\lambda s`, i.e.
+            :math:`\\lambda s \\sim Uniform(\\text{alpha}, 1.0)`.The probability of choosing the object :math:`x_i` from
+            the query set :math:`Q = \\{x_1, \\ldots ,x_n\\}` is evaluated in :meth:`get_probabilities`.
 
             Parameters
             ----------
@@ -303,11 +303,11 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
         """
             Fit a nested logit model on the provided set of queries X and choices Y of those objects. The provided
             queries and corresponding preferences are of a fixed size (numpy arrays). For learning this network the
-            categorical cross entropy loss function for each object :math:`x_i \in Q` is defined as:
+            categorical cross entropy loss function for each object :math:`x_i \\in Q` is defined as:
 
             .. math::
 
-                C_{i} =  -y(i)\log(P_i) \enspace,
+                C_{i} =  -y(i)\\log(P_i) \\enspace,
 
             where :math:`y` is ground-truth discrete choice vector of the objects in the given query set :math:`Q`.
             The value :math:`y(i) = 1` if object :math:`x_i` is chosen else :math:`y(i) = 0`.

--- a/csrank/discretechoice/paired_combinatorial_logit.py
+++ b/csrank/discretechoice/paired_combinatorial_logit.py
@@ -24,24 +24,24 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
             Create an instance of the Paired Combinatorial Logit model for learning the discrete choice function. This
             model considering each pair of objects as a different nest allowing unique covariances for each pair of objects,
             and each object is a member of :math:`n - 1` nests. This model structure is 1-layer of hierarchy and the
-            :math:`\lambda` for each nest :math:`B_k` signifies the degree of independence and  :math:`1-\lambda` signifies
-            the correlations between the object in it. We learn two weight vectors and the  :math:`\lambda s`.
-                * **weights** (:math:`w`): Weights to get the utility of the object :math:`Y_i = U(x_i) = w \cdot x_i`
-                * **lambda_k** (:math:`\lambda_k`): Lambda for nest nest :math:`B_k` for correlations between the obejcts.
+            :math:`\\lambda` for each nest :math:`B_k` signifies the degree of independence and  :math:`1-\\lambda` signifies
+            the correlations between the object in it. We learn two weight vectors and the  :math:`\\lambda s`.
+                * **weights** (:math:`w`): Weights to get the utility of the object :math:`Y_i = U(x_i) = w \\cdot x_i`
+                * **lambda_k** (:math:`\\lambda_k`): Lambda for nest nest :math:`B_k` for correlations between the obejcts.
 
             The probability of choosing an object :math:`x_i` from the given query set :math:`Q` is defined by product
             of choosing the nest in which :math:`x_i` exists and then choosing the the object from the nest.
 
             .. math::
 
-                P(x_i \\lvert Q) = P_i = \sum_{\substack{B_k \in \mathcal{B} \\ i \in B_k}}P_{i \\lvert B_k} P_{B_k} \enspace ,
+                P(x_i \\lvert Q) = P_i = \\sum_{\\substack{B_k \\in \\mathcal{B} \\ i \\in B_k}}P_{i \\lvert B_k} P_{B_k} \\enspace ,
 
 
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x_i \in Q }  \; P(x_i \\lvert Q)
+                dc(Q) := \\operatorname{argmax}_{x_i \\in Q }  \\; P(x_i \\lvert Q)
 
             Parameters
             ----------
@@ -101,17 +101,17 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{b}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{b}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Laplace}(\\text{mu}=\\text{mu}_w, \\text{b}=\\text{b}_w)
 
             For ``l2`` regularization the priors are:
 
             .. math::
 
-                \\text{mu}_w \sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
-                \\text{sd}_w \sim \\text{HalfCauchy}(\\beta=1.0) \\\\
-                \\text{weights} \sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
+                \\text{mu}_w \\sim \\text{Normal}(\\text{mu}=0, \\text{sd}=5.0) \\\\
+                \\text{sd}_w \\sim \\text{HalfCauchy}(\\beta=1.0) \\\\
+                \\text{weights} \\sim \\text{Normal}(\\text{mu}=\\text{mu}_w, \\text{sd}=\\text{sd}_w)
 
             Returns
             -------
@@ -136,22 +136,22 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
         """
             This method calculates the probability of choosing an object from the query set using the following parameters of the model which are used:
 
-                * **weights** (:math:`w`): Weights to get the utility of the object :math:`Y_i = U(x_i) = w \cdot x_i`
-                * **lambda_k** (:math:`\lambda_k`): Lambda is the measure of independence amongst the obejcts in the nest :math:`B_k`
+                * **weights** (:math:`w`): Weights to get the utility of the object :math:`Y_i = U(x_i) = w \\cdot x_i`
+                * **lambda_k** (:math:`\\lambda_k`): Lambda is the measure of independence amongst the obejcts in the nest :math:`B_k`
 
             The probability of choosing the object  :math:`x_i` from the query set :math:`Q`:
 
             .. math::
-                    P_i = \sum_{j \in I \setminus i} P_{{i} \\lvert {ij}} P_{ij} \enspace where, \\\\
-                    P_{i \\lvert ij} = \\frac{\\boldsymbol{e}^{^{Y_i} /_{\lambda_{ij}}}}{\\boldsymbol{e}^{^{Y_i} /_{\lambda_{ij}}} + \\boldsymbol{e}^{^{Y_j} /_{\lambda_{ij}}}} \enspace ,\\\\
-                    P_{ij} = \\frac{{\\left( \\boldsymbol{e}^{^{V_i}/{\lambda_{ij}}} + \\boldsymbol{e}^{^{V_j}/{\lambda_{ij}}}  \\right)}^{\lambda_{ij}}}{\sum_{k=1}^{n-1} \sum_{\ell = k + 1}^{n} {\\left( \\boldsymbol{e}^{^{V_k}/{\lambda_{k\ell}}} + \\boldsymbol{e}^{^{V_{\ell}}/{\lambda_{k\ell}}}  \\right)}^{\lambda_{k\ell}}}
+                    P_i = \\sum_{j \\in I \\setminus i} P_{{i} \\lvert {ij}} P_{ij} \\enspace where, \\\\
+                    P_{i \\lvert ij} = \\frac{\\boldsymbol{e}^{^{Y_i} /_{\\lambda_{ij}}}}{\\boldsymbol{e}^{^{Y_i} /_{\\lambda_{ij}}} + \\boldsymbol{e}^{^{Y_j} /_{\\lambda_{ij}}}} \\enspace ,\\\\
+                    P_{ij} = \\frac{{\\left( \\boldsymbol{e}^{^{V_i}/{\\lambda_{ij}}} + \\boldsymbol{e}^{^{V_j}/{\\lambda_{ij}}}  \\right)}^{\\lambda_{ij}}}{\\sum_{k=1}^{n-1} \\sum_{\\ell = k + 1}^{n} {\\left( \\boldsymbol{e}^{^{V_k}/{\\lambda_{k\\ell}}} + \\boldsymbol{e}^{^{V_{\\ell}}/{\\lambda_{k\\ell}}}  \\right)}^{\\lambda_{k\\ell}}}
 
 
             Parameters
             ----------
             utility : theano tensor
                 (n_instances, n_objects)
-                Utility :math:`Y_i` of the objects :math:`x_i \in Q` in the query sets
+                Utility :math:`Y_i` of the objects :math:`x_i \\in Q` in the query sets
             lambda_k : theano tensor (range : [alpha, 1.0])
                 (n_nests)
                 Measure of independence amongst the obejcts in each nests
@@ -160,7 +160,7 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
             -------
             p : theano tensor
                 (n_instances, n_objects)
-                Choice probabilities :math:`P_i` of the objects :math:`x_i \in Q` in the query sets
+                Choice probabilities :math:`P_i` of the objects :math:`x_i \\in Q` in the query sets
 
         """
         n_objects = self.n_objects
@@ -209,8 +209,8 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
     def construct_model(self, X, Y):
         """
             Constructs the nested logit model by applying priors on weight vectors **weights** as per :meth:`model_configuration`.
-            Then we apply a uniform prior to the :math:`\lambda s`, i.e. :math:`\lambda s \sim Uniform(\\text{alpha}, 1.0)`.
-            The probability of choosing the object :math:`x_i` from the query set :math:`Q = \{x_1, \ldots ,x_n\}` is
+            Then we apply a uniform prior to the :math:`\\lambda s`, i.e. :math:`\\lambda s \\sim Uniform(\\text{alpha}, 1.0)`.
+            The probability of choosing the object :math:`x_i` from the query set :math:`Q = \\{x_1, \\ldots ,x_n\\}` is
             evaluated in :meth:`get_probabilities`.
 
             Parameters
@@ -242,11 +242,11 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
         """
            Fit a paired combinatorial logit  model on the provided set of queries X and choices Y of those objects. The
            provided queries and corresponding preferences are of a fixed size (numpy arrays). For learning this network
-           the categorical cross entropy loss function for each object :math:`x_i \in Q` is defined as:
+           the categorical cross entropy loss function for each object :math:`x_i \\in Q` is defined as:
 
            .. math::
 
-               C_{i} =  -y(i)\log(P_i) \enspace,
+               C_{i} =  -y(i)\\log(P_i) \\enspace,
 
            where :math:`y` is ground-truth discrete choice vector of the objects in the given query set :math:`Q`.
            The value :math:`y(i) = 1` if object :math:`x_i` is chosen else :math:`y(i) = 0`.

--- a/csrank/discretechoice/pairwise_discrete_choice.py
+++ b/csrank/discretechoice/pairwise_discrete_choice.py
@@ -10,13 +10,13 @@ class PairwiseSVMDiscreteChoiceFunction(PairwiseSVM, DiscreteObjectChooser):
                  fit_intercept=True, random_state=None, **kwargs):
         """
             Create an instance of the :class:`PairwiseSVM` model for learning a discrete choice function.
-            It learns a linear deterministic utility function of the form :math:`U(x) = w \cdot x`, where :math:`w` is
+            It learns a linear deterministic utility function of the form :math:`U(x) = w \\cdot x`, where :math:`w` is
             the weight vector. It is estimated using *pairwise preferences* generated from the discrete choices.
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                ρ(Q)  = \operatorname{argmax}_{x \in Q}  \; U(x)
+                ρ(Q)  = \\operatorname{argmax}_{x \\in Q}  \\; U(x)
 
             Parameters
             ----------

--- a/csrank/discretechoice/ranknet_discrete_choice.py
+++ b/csrank/discretechoice/ranknet_discrete_choice.py
@@ -17,14 +17,14 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
             Create an instance of the :class:`RankNetCore` architecture for learning a choice function.
             It breaks the preferences into pairwise comparisons and learns a latent utility model for the objects.
             This network learns a latent utility score for each object in the given query set
-            :math:`Q = \{x_1, \ldots ,x_n\}` using the equation :math:`U(x) = F(x, w)` where :math:`w` is the weight
+            :math:`Q = \\{x_1, \\ldots ,x_n\\}` using the equation :math:`U(x) = F(x, w)` where :math:`w` is the weight
             vector. It is estimated using *pairwise preferences* generated from the discrete choices.
 
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                ρ(Q)  = \operatorname{argsort}_{x \in Q}  \; U(x)
+                ρ(Q)  = \\operatorname{argsort}_{x \\in Q}  \\; U(x)
 
             Parameters
             ----------

--- a/csrank/metrics.py
+++ b/csrank/metrics.py
@@ -224,7 +224,7 @@ def err(y_true, y_pred, utility_function=None, probability_mapping=None):
         reciprocal of the rank (resulting in the ERR metric). If a
         different utility is specified, this function can compute any
         cascade metric. Corresponds to the function represented by
-        :math:`\phi` in [1]. This will usually be a monotonically
+        :math:`\\phi` in [1]. This will usually be a monotonically
         decreasing function, since the user is more likely to examine
         the first few results and therefore more likely to derive
         utility from them.

--- a/csrank/objectranking/cmp_net.py
+++ b/csrank/objectranking/cmp_net.py
@@ -22,18 +22,18 @@ class CmpNet(CmpNetCore, ObjectRanker):
             objects and the pairwise predicate is evaluated using them. The outputs of the network, i.e.,
             :math:`U(x_1,x_2), U(x_2,x_1)`for each pair of objects are evaluated.
             :math:`U(x_1,x_2)` is a measure of how favorable it is to choose :math:`x_1` over :math:`x_2`.
-            The utility score of object :math:`x_i` in query set :math:`Q = \{ x_1 , \ldots , x_n \}` is evaluated as:
+            The utility score of object :math:`x_i` in query set :math:`Q = \\{ x_1 , \\ldots , x_n \\}` is evaluated as:
 
             .. math::
 
-                U(x_i) = \left\{ \\frac{1}{n-1} \sum_{j \in [n] \setminus \{i\}} U_1(x_i , x_j)\\right\}
+                U(x_i) = \\left\\{ \\frac{1}{n-1} \\sum_{j \\in [n] \\setminus \\{i\\}} U_1(x_i , x_j)\\right\\}
 
 
             The ranking for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                ρ(Q)  = \operatorname{argsort}_{x \in Q}  \; U(x)
+                ρ(Q)  = \\operatorname{argsort}_{x \\in Q}  \\; U(x)
 
 
            Parameters
@@ -97,14 +97,14 @@ class CmpNet(CmpNetCore, ObjectRanker):
         """
             Fit an object ranking learning CmpNet model on a provided set of queries. The provided queries can be of a
             fixed size (numpy arrays). For learning this network the binary cross entropy loss function for a pair of
-            objects :math:`x_i, x_j \in Q` is defined as:
+            objects :math:`x_i, x_j \\in Q` is defined as:
 
             .. math::
 
-                C_{ij} =  -\\tilde{P_{ij}}(0)\\cdot \log(U(x_i,x_j)) - \\tilde{P_{ij}}(1) \\cdot \log(U(x_j,x_i)) \ ,
+                C_{ij} =  -\\tilde{P_{ij}}(0)\\cdot \\log(U(x_i,x_j)) - \\tilde{P_{ij}}(1) \\cdot \\log(U(x_j,x_i)) \\ ,
 
             where :math:`\\tilde{P_{ij}}` is ground truth probability of the preference of :math:`x_i` over :math:`x_j`.
-            :math:`\\tilde{P_{ij}} = (1,0)` if :math:`x_i \succ x_j` else :math:`\\tilde{P_{ij}} = (0,1)`.
+            :math:`\\tilde{P_{ij}} = (1,0)` if :math:`x_i \\succ x_j` else :math:`\\tilde{P_{ij}} = (0,1)`.
 
             Parameters
             ----------

--- a/csrank/objectranking/expected_rank_regression.py
+++ b/csrank/objectranking/expected_rank_regression.py
@@ -21,17 +21,17 @@ class ExpectedRankRegression(ObjectRanker, Learner):
             Create an expected rank regression model.
             This model normalizes the ranks to [0, 1] and treats them as regression target. For ``α = 0`` we employ
             simple linear regression. For α > 0 the model becomes ridge regression (when ``l1_ratio = 0``) or
-            elastic net (when ``l1_ratio > 0``). The target for an object :math:`x_k \in Q` is:
+            elastic net (when ``l1_ratio > 0``). The target for an object :math:`x_k \\in Q` is:
 
 
             .. math::
-                r(x_k) = \\frac{\pi(k)}{n} \quad ,
+                r(x_k) = \\frac{\\pi(k)}{n} \\quad ,
 
-            where :math:`\pi(k)` is the rank of the :math:`x_k`. The regression model learns a function
-            :math:`F \colon \mathcal{X} \\to \mathbb{R}`. The ranking for the given query set :math:`Q` defined as:
+            where :math:`\\pi(k)` is the rank of the :math:`x_k`. The regression model learns a function
+            :math:`F \\colon \\mathcal{X} \\to \\mathbb{R}`. The ranking for the given query set :math:`Q` defined as:
 
             .. math::
-                ρ(Q)  = \operatorname{argsort}_{x \in Q}  \; -1*F(x)
+                ρ(Q)  = \\operatorname{argsort}_{x \\in Q}  \\; -1*F(x)
 
 
             Parameters

--- a/csrank/objectranking/fate_object_ranker.py
+++ b/csrank/objectranking/fate_object_ranker.py
@@ -26,13 +26,13 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
             .. math::
                 \\mu_{C(x)} = \\frac{1}{\\lvert C(x) \\lvert} \\sum_{y \\in C(x)} \\phi(y)
 
-            where :math:`\phi \colon \mathcal{X} \\to \mathcal{Z}` maps each object :math:`y` to an
-            :math:`m`-dimensional embedding space :math:`\mathcal{Z} \subseteq \mathbb{R}^m`.
+            where :math:`\\phi \\colon \\mathcal{X} \\to \\mathcal{Z}` maps each object :math:`y` to an
+            :math:`m`-dimensional embedding space :math:`\\mathcal{Z} \\subseteq \\mathbb{R}^m`.
             Training complexity is quadratic in the number of objects and prediction complexity is only linear.
             The ranking for the given query set :math:`Q` is defined as:
 
             .. math::
-                ρ(Q)  = \operatorname{argsort}_{x \in Q}  \; U (x, \\mu_{C(x)})
+                ρ(Q)  = \\operatorname{argsort}_{x \\in Q}  \\; U (x, \\mu_{C(x)})
 
             Parameters
             ----------

--- a/csrank/objectranking/fatelinear_object_ranker.py
+++ b/csrank/objectranking/fatelinear_object_ranker.py
@@ -19,14 +19,14 @@ class FATELinearObjectRanker(FATELinearCore, ObjectRanker):
             .. math::
                 \\mu_{C(x)} = \\frac{1}{\\lvert C(x) \\lvert} \\sum_{y \\in C(x)} \\phi(y)
 
-            where :math:`\phi \colon \mathcal{X} \\to \mathcal{Z}` maps each object :math:`y` to an
-            :math:`m`-dimensional embedding space :math:`\mathcal{Z} \subseteq \mathbb{R}^m`.
+            where :math:`\\phi \\colon \\mathcal{X} \\to \\mathcal{Z}` maps each object :math:`y` to an
+            :math:`m`-dimensional embedding space :math:`\\mathcal{Z} \\subseteq \\mathbb{R}^m`.
             Training complexity is quadratic in the number of objects and prediction complexity is only linear.
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x \in Q}  \;  U (x, \\mu_{C(x)})
+                dc(Q) := \\operatorname{argmax}_{x \\in Q}  \\;  U (x, \\mu_{C(x)})
 
             Parameters
             ----------

--- a/csrank/objectranking/feta_object_ranker.py
+++ b/csrank/objectranking/feta_object_ranker.py
@@ -19,18 +19,18 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
         """
             Create a FETA-network architecture for object ranking. The first-evaluate-then-aggregate approach
             approximates the context-dependent utility function using the first-order utility function
-            :math:`U_1 \colon \mathcal{X} \\times \mathcal{X} \\rightarrow [0,1]` and zeroth-order utility
-            function :math:`U_0 \colon \mathcal{X} \\rightarrow [0,1]`.
+            :math:`U_1 \\colon \\mathcal{X} \\times \\mathcal{X} \\rightarrow [0,1]` and zeroth-order utility
+            function :math:`U_0 \\colon \\mathcal{X} \\rightarrow [0,1]`.
             The scores each object :math:`x` using a context-dependent utility function :math:`U (x, C_i)`:
 
             .. math::
-                 U(x_i, C_i) = U_0(x_i) + \\frac{1}{n-1} \sum_{x_j \in Q \\setminus \{x_i\}} U_1(x_i , x_j) \, .
+                 U(x_i, C_i) = U_0(x_i) + \\frac{1}{n-1} \\sum_{x_j \\in Q \\setminus \\{x_i\\}} U_1(x_i , x_j) \\, .
 
             Training and prediction complexity is quadratic in the number of objects.
             The ranking for the given query set :math:`Q` is defined as:
 
             .. math::
-                ρ(Q)  = \operatorname{argsort}_{x_i \in Q}  \; U (x_i, C_i)
+                ρ(Q)  = \\operatorname{argsort}_{x_i \\in Q}  \\; U (x_i, C_i)
 
             Parameters
             ----------

--- a/csrank/objectranking/fetalinear_object_ranker.py
+++ b/csrank/objectranking/fetalinear_object_ranker.py
@@ -19,14 +19,14 @@ class FETALinearObjectRanker(FETALinearCore, ObjectRanker):
             .. math::
                 \\mu_{C(x)} = \\frac{1}{\\lvert C(x) \\lvert} \\sum_{y \\in C(x)} \\phi(y)
 
-            where :math:`\phi \colon \mathcal{X} \\to \mathcal{Z}` maps each object :math:`y` to an
-            :math:`m`-dimensional embedding space :math:`\mathcal{Z} \subseteq \mathbb{R}^m`.
+            where :math:`\\phi \\colon \\mathcal{X} \\to \\mathcal{Z}` maps each object :math:`y` to an
+            :math:`m`-dimensional embedding space :math:`\\mathcal{Z} \\subseteq \\mathbb{R}^m`.
             Training complexity is quadratic in the number of objects and prediction complexity is only linear.
             The discrete choice for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                dc(Q) := \operatorname{argmax}_{x \in Q}  \;  U (x, \\mu_{C(x)})
+                dc(Q) := \\operatorname{argmax}_{x \\in Q}  \\;  U (x, \\mu_{C(x)})
 
             Parameters
             ----------

--- a/csrank/objectranking/list_net.py
+++ b/csrank/objectranking/list_net.py
@@ -27,13 +27,13 @@ class ListNet(Learner, ObjectRanker):
                  metrics=[zero_one_rank_loss_for_scores_ties], batch_size=256, random_state=None, **kwargs):
         """ Create an instance of the ListNet architecture. ListNet trains a latent utility model based on
             top-k-subrankings of the objects. This network learns a latent utility score for each object in the given
-            query set :math:`Q = \{x_1, \ldots ,x_n\}` using the equation :math:`U(x) = F(x, w)` where :math:`w` is the
+            query set :math:`Q = \\{x_1, \\ldots ,x_n\\}` using the equation :math:`U(x) = F(x, w)` where :math:`w` is the
             weight vector. A listwise loss function like the negative Plackett-Luce likelihood is used for training.
             The ranking for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                ρ(Q)  = \operatorname{argsort}_{x \in Q}  \; U(x)
+                ρ(Q)  = \\operatorname{argsort}_{x \\in Q}  \\; U(x)
 
             Parameters
             ----------
@@ -126,11 +126,11 @@ class ListNet(Learner, ObjectRanker):
         """
             Fit an object ranking learning ListNet on the top-k-subrankings in the provided set of queries. The provided
             queries can be of a fixed size (numpy arrays). For fitting the model we maximize the Plackett-Luce
-            likelihood. For example for query set :math:`Q = \{x_1,x_2,x_3\}`, the scores are :math:`Q = (s_1,s_2,s_3)`
-            and the ranking is :math:`\pi = (3,1,2)`. The  Plackett-Luce likelihood is defined as:
+            likelihood. For example for query set :math:`Q = \\{x_1,x_2,x_3\\}`, the scores are :math:`Q = (s_1,s_2,s_3)`
+            and the ranking is :math:`\\pi = (3,1,2)`. The  Plackett-Luce likelihood is defined as:
 
             .. math::
-                P_l(\pi) = \\frac{s_2}{s_1+s_2+s_3} \cdot \\frac{s_3}{s_1+s_3} \cdot \\frac{s_1}{s_1}
+                P_l(\\pi) = \\frac{s_2}{s_1+s_2+s_3} \\cdot \\frac{s_3}{s_1+s_3} \\cdot \\frac{s_1}{s_1}
 
             Note: For k=2 we obtain :class:`RankNet` as a special case.
 
@@ -189,7 +189,7 @@ class ListNet(Learner, ObjectRanker):
     def scoring_model(self):
         """
             Creates a scoring model from the trained ListNet, which predicts the utility scores for given set of objects.
-            This network consist of a sequential network which predicts the utility score for each object :math:`x \in Q`
+            This network consist of a sequential network which predicts the utility score for each object :math:`x \\in Q`
             using the latent utility function :math:`U(x) = F(x, w)` where :math:`w` is the weights of the model.
 
             Returns

--- a/csrank/objectranking/object_ranker.py
+++ b/csrank/objectranking/object_ranker.py
@@ -14,8 +14,8 @@ class ObjectRanker(metaclass=ABCMeta):
 
     def predict_for_scores(self, scores, **kwargs):
         """
-            The permutation vector :math:`\pi` represents the ranking amongst the objects in :math:`Q`, such that
-            :math:`\pi(k)` is the position of the :math:`k`-th object :math:`x_k`, and :math:`\pi^{-1}(k)` is the index
+            The permutation vector :math:`\\pi` represents the ranking amongst the objects in :math:`Q`, such that
+            :math:`\\pi(k)` is the position of the :math:`k`-th object :math:`x_k`, and :math:`\\pi^{-1}(k)` is the index
             of the object on position :math:`k`. Predict rankings for the scores for a given collection of sets of
             objects (query sets).
 

--- a/csrank/objectranking/rank_net.py
+++ b/csrank/objectranking/rank_net.py
@@ -18,13 +18,13 @@ class RankNet(RankNetCore, ObjectRanker):
         """ Create an instance of the :class:`RankNetCore` architecture for learning a object ranking function.
             It breaks the preferences into pairwise comparisons and learns a latent utility model for the objects.
             This network learns a latent utility score for each object in the given query set
-            :math:`Q = \{x_1, \ldots ,x_n\}` using the equation :math:`U(x) = F(x, w)` where :math:`w` is the weight
+            :math:`Q = \\{x_1, \\ldots ,x_n\\}` using the equation :math:`U(x) = F(x, w)` where :math:`w` is the weight
             vector. It is estimated using *pairwise preferences* generated from the rankings.
             The ranking for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                ρ(Q)  = \operatorname{argsort}_{x \in Q}  \; U(x)
+                ρ(Q)  = \\operatorname{argsort}_{x \\in Q}  \\; U(x)
 
             Parameters
             ----------
@@ -90,14 +90,14 @@ class RankNet(RankNetCore, ObjectRanker):
         """
             Fit an object ranking learning RankNet model on a provided set of queries. The provided queries can be of a
             fixed size (numpy arrays). For learning this network the binary cross entropy loss function for a pair of
-            objects :math:`x_i, x_j \in Q` is defined as:
+            objects :math:`x_i, x_j \\in Q` is defined as:
 
             .. math::
 
-                C_{ij} =  -\\tilde{P_{ij}}\log(P_{ij}) - (1 - \\tilde{P_{ij}})\log(1 - P{ij}) \enspace,
+                C_{ij} =  -\\tilde{P_{ij}}\\log(P_{ij}) - (1 - \\tilde{P_{ij}})\\log(1 - P{ij}) \\enspace,
 
             where :math:`\\tilde{P_{ij}}` is ground truth probability of the preference of :math:`x_i` over :math:`x_j`.
-            :math:`\\tilde{P_{ij}} = 1` if :math:`x_i \succ x_j` else :math:`\\tilde{P_{ij}} = 0`.
+            :math:`\\tilde{P_{ij}} = 1` if :math:`x_i \\succ x_j` else :math:`\\tilde{P_{ij}} = 0`.
 
             Parameters
             ----------

--- a/csrank/objectranking/rank_svm.py
+++ b/csrank/objectranking/rank_svm.py
@@ -13,13 +13,13 @@ class RankSVM(ObjectRanker, PairwiseSVM):
                  fit_intercept=True, random_state=None, **kwargs):
         """
             Create an instance of the :class:`PairwiseSVM` model for learning a object ranking function.
-            It learns a linear deterministic utility function of the form :math:`U(x) = w \cdot x`, where :math:`w` is
+            It learns a linear deterministic utility function of the form :math:`U(x) = w \\cdot x`, where :math:`w` is
             the weight vector. It is estimated using *pairwise preferences* generated from the rankings.
             The ranking for the given query set :math:`Q` is defined as:
 
             .. math::
 
-                ρ(Q)  = \operatorname{argsort}_{x \in Q}  \; U(x)
+                ρ(Q)  = \\operatorname{argsort}_{x \\in Q}  \\; U(x)
 
             Parameters
             ----------


### PR DESCRIPTION
## Description

We need to escape backslashes in latex code, since python otherwise
interprets \c as an escaped unicode character.

Fixes #59

## Motivation and Context

Without this, there are a lot of warnings during testing. Also, sphinx probably wouldn't render the math correctly. There was even one instance of a regular expression that would lead to bugs at runtime.

## How Has This Been Tested?

Ran all tests.

## Does this close/impact existing issues?

#59 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
