### PR TITLE
Ignore some warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,18 @@
 [pytest]
 addopts = --doctest-modules
+filterwarnings =
+	; caused by keras
+	ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning
+	ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated.*:DeprecationWarning
+	; caused by theano
+	ignore:Importing from numpy.testing.nosetester is deprecated since 1.15.0.*:DeprecationWarning
+
+	; caused by scikit-optimize (https://github.com/scikit-optimize/scikit-optimize/issues/774). Cannot currently be reliably ignored, but this will work in the future (https://github.com/scikit-learn/scikit-learn/issues/9857)
+	ignore:sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib.*:FutureWarning
+
+	; not sure what causes these, but its not cs-ranking
+	ignore:Keyword argument varnames renamed to var_names.*:DeprecationWarning
+	ignore:The join_axes-keyword is deprecated.*:FutureWarning
+
+	; pymc complains about small sample size, which is fine for tests
+	ignore:The number of samples is too small to check convergence reliably:UserWarning


### PR DESCRIPTION
## Description

We do not have control about any of these warnings except the last one.
And that one is harmless in a testing context.

Maintaining a list of these filters is cumbersome. I wish there was some
way to automatically ignore all warnings caused by third party code, but
unfortunately I don't think there currently is. I've opened
https://github.com/pytest-dev/pytest/issues/6191
to discuss this.

I still think it is worthwhile to filter these warnings, because
otherwise they drown out those warnings that are actually relevant.

## How Has This Been Tested?

Ran all tests.

## Does this close/impact existing issues?

Related to https://github.com/kiudee/cs-ranking/issues/59.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
