### PR TITLE
Ignore numpy warning that is caused by theano

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,7 @@ filterwarnings =
 
 	; pymc complains about small sample size, which is fine for tests
 	ignore:The number of samples is too small to check convergence reliably:UserWarning
+
+	; theano internally uses some deprecated numpy api, which is fixed upstream but not released yet
+	; (https://github.com/kiudee/cs-ranking/issues/74)
+	ignore:Using a non-tuple sequence for multidimensional indexing is deprecated:FutureWarning


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Out of our control.

Fixes #74

## Motivation and Context

The goal is to have the testsuite not emit any warnings. That way we can easily catch new warnings as they arise.

## How Has This Been Tested?

Ran all tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
