### PR TITLE
Remove usage of Imputer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 
-cache:
-  directories:
-    - $HOME/miniconda3
-
 addons:
   apt_packages:
     - pandoc

--- a/csrank/choicefunction/generalized_linear_model.py
+++ b/csrank/choicefunction/generalized_linear_model.py
@@ -203,7 +203,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
     def _predict_scores_fixed(self, X, **kwargs):
         d = dict(pm.summary(self.trace)['mean'])
         intercept = 0.0
-        weights = np.array([d['weights__{}'.format(i)] for i in range(self.n_object_features)])
+        weights = np.array([d['weights[{}]'.format(i)] for i in range(self.n_object_features)])
         if 'intercept' in d:
             intercept = intercept + d['intercept']
         return np.dot(X, weights) + intercept

--- a/csrank/dataset_reader/labelranking/survey_dataset_reader.py
+++ b/csrank/dataset_reader/labelranking/survey_dataset_reader.py
@@ -3,7 +3,8 @@ import os
 import numpy as np
 import pandas as pd
 from sklearn.model_selection import ShuffleSplit
-from sklearn.preprocessing import Imputer, StandardScaler
+from sklearn.preprocessing import StandardScaler
+from sklearn.impute import SimpleImputer
 from sklearn.utils import check_random_state
 
 from csrank.constants import LABEL_RANKING
@@ -28,7 +29,7 @@ class SurveyDatasetReader(DatasetReader):
             context_feature = [float(i) if i != '.' else np.NAN for i in row[13:33]]
             features.append(context_feature)
         X = np.array(features)
-        X = Imputer().fit_transform(X)
+        X = SimpleImputer().fit_transform(X)
         X = np.array([np.log(np.array(X[:, i]) + 1) for i in range(len(features[0]))])
         X = np.array(X.T)
         self.X = StandardScaler().fit_transform(X)

--- a/csrank/discretechoice/generalized_nested_logit.py
+++ b/csrank/discretechoice/generalized_nested_logit.py
@@ -283,11 +283,11 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
 
     def _predict_scores_fixed(self, X, **kwargs):
         mean_trace = dict(pm.summary(self.trace)['mean'])
-        weights = np.array([mean_trace['weights__{}'.format(i)] for i in range(self.n_object_features)])
-        lambda_k = np.array([mean_trace['lambda_k__{}'.format(i)] for i in range(self.n_nests)])
+        weights = np.array([mean_trace['weights[{}]'.format(i)] for i in range(self.n_object_features)])
+        lambda_k = np.array([mean_trace['lambda_k[{}]'.format(i)] for i in range(self.n_nests)])
         weights_ik = np.zeros((self.n_object_features, self.n_nests))
         for i, k in product(range(self.n_object_features), range(self.n_nests)):
-            weights_ik[i][k] = mean_trace['weights_ik__{}_{}'.format(i, k)]
+            weights_ik[i][k] = mean_trace['weights_ik[{},{}]'.format(i, k)]
         alpha_ik = np.dot(X, weights_ik)
         alpha_ik = npu.softmax(alpha_ik, axis=2)
         utility = np.dot(X, weights)

--- a/csrank/discretechoice/mixed_logit_model.py
+++ b/csrank/discretechoice/mixed_logit_model.py
@@ -187,7 +187,7 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
         summary = dict(pm.summary(self.trace)['mean'])
         weights = np.zeros((self.n_object_features, self.n_mixtures))
         for i, k in product(range(self.n_object_features), range(self.n_mixtures)):
-            weights[i][k] = summary['weights__{}_{}'.format(i, k)]
+            weights[i][k] = summary['weights[{},{}]'.format(i, k)]
         utility = np.dot(X, weights)
         p = np.mean(npu.softmax(utility, axis=1), axis=2)
         return p

--- a/csrank/discretechoice/multinomial_logit_model.py
+++ b/csrank/discretechoice/multinomial_logit_model.py
@@ -181,7 +181,7 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
     def _predict_scores_fixed(self, X, **kwargs):
         d = dict(pm.summary(self.trace)['mean'])
         intercept = 0.0
-        weights = np.array([d['weights__{}'.format(i)] for i in range(self.n_object_features)])
+        weights = np.array([d['weights[{}]'.format(i)] for i in range(self.n_object_features)])
         if 'intercept' in d:
             intercept = intercept + d['intercept']
         return np.dot(X, weights) + intercept

--- a/csrank/discretechoice/nested_logit_model.py
+++ b/csrank/discretechoice/nested_logit_model.py
@@ -342,9 +342,9 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
     def _predict_scores_fixed(self, X, **kwargs):
         y_nests = self.create_nests(X)
         mean_trace = dict(pm.summary(self.trace)['mean'])
-        weights = np.array([mean_trace['weights__{}'.format(i)] for i in range(self.n_object_features)])
-        weights_k = np.array([mean_trace['weights_k__{}'.format(i)] for i in range(self.n_object_features)])
-        lambda_k = np.array([mean_trace['lambda_k__{}'.format(i)] for i in range(self.n_nests)])
+        weights = np.array([mean_trace['weights[{}]'.format(i)] for i in range(self.n_object_features)])
+        weights_k = np.array([mean_trace['weights_k[{}]'.format(i)] for i in range(self.n_object_features)])
+        lambda_k = np.array([mean_trace['lambda_k[{}]'.format(i)] for i in range(self.n_nests)])
         weights = (weights / lambda_k[:, None])
         utility_k = np.dot(self.features_nests, weights_k)
         utility = self._eval_utility_np(X, y_nests, weights)

--- a/csrank/discretechoice/paired_combinatorial_logit.py
+++ b/csrank/discretechoice/paired_combinatorial_logit.py
@@ -280,8 +280,8 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
 
     def _predict_scores_fixed(self, X, **kwargs):
         mean_trace = dict(pm.summary(self.trace)['mean'])
-        weights = np.array([mean_trace['weights__{}'.format(i)] for i in range(self.n_object_features)])
-        lambda_k = np.array([mean_trace['lambda_k__{}'.format(i)] for i in range(self.n_nests)])
+        weights = np.array([mean_trace['weights[{}]'.format(i)] for i in range(self.n_object_features)])
+        lambda_k = np.array([mean_trace['lambda_k[{}]'.format(i)] for i in range(self.n_nests)])
         utility = np.dot(X, weights)
         p = self._get_probabilities_np(utility, lambda_k)
         return p

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ docopt>=0.6.0
 joblib>=0.9.4
 tqdm>=4.11.2
 keras>=2.3
-pymc3>=3.5
+pymc3>=3.8
 theano>=1.0
 # Pick either CPU or GPU version of tensorflow:
 tensorflow>=1.5,<2.0

--- a/scripts/create_testenv.sh
+++ b/scripts/create_testenv.sh
@@ -22,7 +22,7 @@ then
 fi
 
 
-conda install --yes numpy scipy joblib pytest pytest-cov coverage scikit-learn pandas h5py seaborn mkl-service
+conda install --yes numpy scipy joblib pytest pytest-cov coverage pandas h5py seaborn mkl-service
 pip install sphinx sphinx-autobuild nbsphinx pandoc ipykernel bottleneck sphinx_rtd_theme notebook sphinxcontrib-bibtex
 pip install --no-cache-dir --ignore-installed -r requirements.txt
 


### PR DESCRIPTION
## Description

Imputer was removed from preprocessing in
https://github.com/scikit-learn/scikit-learn/pull/13796. To be
compatible with newer scikit-learn versions, we need to stop using it.
impute.SimpleImputer seems to be a viable replacement.

This caused failures on travis.


## Motivation and Context
The latest sklearn caused failures on travis.

## How Has This Been Tested?

Ran all tests with sklearn 0.22.

## Does this close/impact existing issues?

Impacts https://github.com/kiudee/cs-ranking/pull/65, where the CI fails because of this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
