### PR TITLE
Let travis-ci notify coveralls to merge coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,6 @@ deploy:
     on:
       branch: master
       repo: kiudee/cs-ranking
+
+notifications:
+  webhooks: https://coveralls.io/webhook


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a webhook to the .travis.yml file.

## Motivation and Context
The tests are executed in parallel and the last test to finish updates the coverage report. This change should fix this behaviour and produce actually accurate coverage reports.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By doing this pull request.

## Does this close/impact existing issues?
<!--- Please link to all relevant issues. -->
--

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
