### PR TITLE
Add pre-commit configuration and use it in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 cache:
   directories:
     - $HOME/miniconda3
+    - $HOME/.cache/pre-commit
 
 addons:
   apt_packages:
@@ -24,6 +25,7 @@ env:
   - TESTCMD="--cov-append csrank/tests/test_fate.py csrank/tests/test_losses.py csrank/tests/test_metrics.py csrank/tests/test_tuning.py csrank/tests/test_util.py csrank/tests/test_tuning.py csrank/tests/test_callbacks.py"
 
 script:
+  - pre-commit run --all-files # https://pre-commit.com/#usage-in-continuous-integration
   - pytest -v --cov=csrank --ignore experiments $TESTCMD
   - travis-sphinx --outdir docs/_build build -n --source=docs
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ theano>=1.0
 # Pick either CPU or GPU version of tensorflow:
 tensorflow>=1.5,<2.0
 # tensorflow-gpu>=1.0.1
+pre-commit


### PR DESCRIPTION
## Description

Run `black` pre-commit and on CI.

## Motivation and Context

As a follow up to https://github.com/kiudee/cs-ranking/pull/78, we should run `black` locally pre-commit and verify that this was done on CI. Otherwise the formatting would slowly shift away from the black standard again.

## How Has This Been Tested?

By creating this PR.

## Does this close/impact existing issues?

#78

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
