### PR TITLE
Replace coveralls with codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null          # branch names that can post comment

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 
 install:
   - . ./scripts/create_testenv.sh
+  - pip install codecov
   - conda install --yes sphinx ipython
   - pip install -I git+https://github.com/Syntaf/travis-sphinx.git
   - pip install nbsphinx sphinx_rtd_theme
@@ -28,6 +29,9 @@ script:
   - pre-commit run --all-files # https://pre-commit.com/#usage-in-continuous-integration
   - pytest -v --cov=csrank --ignore experiments $TESTCMD
   - travis-sphinx --outdir docs/_build build -n --source=docs
+
+after_success:
+  - codecov
 
 deploy:
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - . ./scripts/create_testenv.sh
   - conda install --yes sphinx ipython
   - pip install -I git+https://github.com/Syntaf/travis-sphinx.git
-  - pip install coveralls nbsphinx sphinx_rtd_theme
+  - pip install nbsphinx sphinx_rtd_theme
 
 env:
   - TESTCMD="--cov-append csrank/tests/test_choice_functions.py"
@@ -28,9 +28,6 @@ script:
   - pre-commit run --all-files # https://pre-commit.com/#usage-in-continuous-integration
   - pytest -v --cov=csrank --ignore experiments $TESTCMD
   - travis-sphinx --outdir docs/_build build -n --source=docs
-
-after_success:
-  - coveralls
 
 deploy:
   - provider: pypi
@@ -49,6 +46,3 @@ deploy:
     on:
       branch: master
       repo: kiudee/cs-ranking
-
-notifications:
-  webhooks: https://coveralls.io/webhook

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build Status| |Binder|
+|Build Status| |Coverage| |Binder|
 
 *******
 CS-Rank
@@ -104,6 +104,9 @@ License
 
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/kiudee/cs-ranking/master?filepath=docs%2Fnotebooks
+
+.. |Coverage| image:: https://codecov.io/gh/kiudee/cs-ranking/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/kiudee/cs-ranking
 
 .. |Build Status| image:: https://travis-ci.org/kiudee/cs-ranking.svg?branch=master
    :target: https://travis-ci.org/kiudee/cs-ranking

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Build Status| |Coverage| |Binder|
+|Build Status| |Binder|
 
 *******
 CS-Rank
@@ -107,9 +107,6 @@ License
 
 .. |Build Status| image:: https://travis-ci.org/kiudee/cs-ranking.svg?branch=master
    :target: https://travis-ci.org/kiudee/cs-ranking
-
-.. |Coverage| image:: https://coveralls.io/repos/github/kiudee/cs-ranking/badge.svg?branch=master
-   :target: https://coveralls.io/github/kiudee/cs-ranking?branch=master
 
 
 .. _interactive notebooks: https://mybinder.org/v2/gh/kiudee/cs-ranking/master?filepath=docs%2Fnotebooks

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,6 +1,6 @@
 .. _intro:
 
-|Build Status| |Coverage| |Binder|
+|Build Status| |Binder|
 
 ************
 Introduction
@@ -107,9 +107,6 @@ License
 
 .. |Build Status| image:: https://travis-ci.org/kiudee/cs-ranking.svg?branch=master
    :target: https://travis-ci.org/kiudee/cs-ranking
-
-.. |Coverage| image:: https://coveralls.io/repos/github/kiudee/cs-ranking/badge.svg
-   :target: https://coveralls.io/github/kiudee/cs-ranking
 
 .. _interactive notebooks: https://mybinder.org/v2/gh/kiudee/cs-ranking/master?filepath=docs%2Fnotebooks
 .. _arXiv papers: https://arxiv.org/search/cs?searchtype=author&query=Pfannschmidt%2C+K

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,6 +1,6 @@
 .. _intro:
 
-|Build Status| |Binder|
+|Build Status| |Coverage| |Binder|
 
 ************
 Introduction
@@ -104,6 +104,9 @@ License
 
 .. |Binder| image:: https://mybinder.org/badge.svg
    :target: https://mybinder.org/v2/gh/kiudee/cs-ranking/master?filepath=docs%2Fnotebooks
+
+.. |Coverage| image:: https://codecov.io/gh/kiudee/cs-ranking/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/kiudee/cs-ranking
 
 .. |Build Status| image:: https://travis-ci.org/kiudee/cs-ranking.svg?branch=master
    :target: https://travis-ci.org/kiudee/cs-ranking


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove coveralls from the repository and set up codecov instead.

## Motivation and Context
We currently use Coveralls to report coverage statistics for each new pull request. Sadly, it does not handle parallel builds correctly and thus is quite useless.
Codecov seems to be widely used, better maintained and can be configured in detail.

## How Has This Been Tested?
By creating this pull request

## Does this close/impact existing issues?
<!--- Please link to all relevant issues. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
