### PR TITLE
Check docs for errors and style mistakes with doc8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,7 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
+  - repo: https://github.com/PyCQA/doc8
+    rev: 0.8.1rc3
+    hooks:
+      - id: doc8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,10 +2,9 @@
 Contributing
 ============
 
-Contributions are welcome, and they are greatly appreciated!
-Every little bit helps.
-Contributions do not have to be source code.
-There are many ways to contribute:
+Contributions are welcome, and they are greatly appreciated! Every little bit
+helps. Contributions do not have to be source code. There are many ways to
+contribute:
 
 Report Bugs
 ===========
@@ -37,13 +36,16 @@ If you are proposing a feature:
 
 * Explain in detail how it would work and why you would want it.
 * Keep the scope as narrow as possible, to make it easier to implement.
-* Remember that this is a volunteer-driven project, and that code contributions are welcome :)
+* Remember that this is a volunteer-driven project, and that code contributions
+  are welcome :)
 
 Write Documentation
 ===================
 
-This project could always use more documentation, whether as part of the official cs-ranking docs, in docstrings, or even on the web in blog posts, articles, and such.
-For writing in-project documentation, the setup is similar to contributing code.
+This project could always use more documentation, whether as part of the
+official cs-ranking docs, in docstrings, or even on the web in blog posts,
+articles, and such. For writing in-project documentation, the setup is similar
+to contributing code.
 
 Contribute Code
 ===============
@@ -155,8 +157,9 @@ Pull Request Guidelines
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. If you're adding new functionality, you should also include *tests* and *documentation* for that functionality.
-   Put your new functionality into a function with a docstring, and add the feature to the list in README.rst.
+1. If you're adding new functionality, you should also include *tests* and
+   *documentation* for that functionality. Put your new functionality into
+   a function with a docstring, and add the feature to the list in README.rst.
    You can also add tests to the docstring:
 
    .. code-block:: python
@@ -176,7 +179,8 @@ Before you submit a pull request, check that it meets these guidelines:
            """
            return input_number + 1
 
-3. After submitting the pull request, keep an eye on travis_ and make sure that the tests pass for all supported Python versions.
+3. After submitting the pull request, keep an eye on travis_ and make sure that
+   the tests pass for all supported Python versions.
 
 .. _travis: https://travis-ci.org/github/kiudee/cs-ranking/pull_requests
 
@@ -192,9 +196,9 @@ To run a subset of tests:
 Help Wanted
 ~~~~~~~~~~~
 
-Look through the GitHub issues.
-Anything tagged with `"bug"`__ and `"help wanted"`__ are particularly good places to get started.
-If you prefer to implement new features, the `"enhancement"`__ tag might be interesting as well.
+Look through the GitHub issues. Anything tagged with `"bug"`__ and `"help
+wanted"`__ are particularly good places to get started. If you prefer to
+implement new features, the `"enhancement"`__ tag might be interesting as well.
 
 __ https://github.com/kiudee/cs-ranking/issues?q=is%3Aissue+is%3Aopen+label%3Abug
 __ https://github.com/kiudee/cs-ranking/issues?q=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22
@@ -203,8 +207,9 @@ __ https://github.com/kiudee/cs-ranking/issues?q=is%3Aissue+is%3Aopen+label%3Aen
 Do Maintenance
 ==============
 
-These tasks are mostly done by project maintainers, though if you think they need to be done you can of course open an issue and ask for it.
-A pull request is even better.
+These tasks are mostly done by project maintainers, though if you think they
+need to be done you can of course open an issue and ask for it. A pull request
+is even better.
 
 Deploying
 ~~~~~~~~~

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -83,6 +83,8 @@ __ https://virtualenvwrapper.readthedocs.io/en/latest/
    previous step. This will make sure that the changes you make adhere to our
    coding standards by checking formatting with `black`.
 
+__ https://pre-commit.com/
+
    .. code-block:: bash
 
        $ pre-commit install

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ algorithms.
 We implement the following new object ranking/choice architectures:
 
 * FATE (First aggregate then evaluate)
-* FETA (First evaluate then aggregate)   
- 
+* FETA (First evaluate then aggregate)
+
 In addition, we also implement these algorithms for choice functions:
 
 * RankNetChoiceFunction
@@ -51,7 +51,7 @@ method:
 .. code-block:: python
 
    fate = cs.FATEChoiceFunction(n_object_features=2)
-   fate.fit(X_train, Y_train) 
+   fate.fit(X_train, Y_train)
 
 Predictions can then be obtained using:
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,8 @@
 *******
 CS-Rank
 *******
-CS-Rank is a Python package for context-sensitive ranking and choice algorithms.
+CS-Rank is a Python package for context-sensitive ranking and choice
+algorithms.
 
 We implement the following new object ranking/choice architectures:
 
@@ -16,7 +17,8 @@ In addition, we also implement these algorithms for choice functions:
 * GeneralizedLinearModel
 * PairwiseSVMChoiceFunction
 
-These are the state-of-the-art approaches implemented for the discrete choice setting:
+These are the state-of-the-art approaches implemented for the discrete choice
+setting:
 
 * GeneralizedNestedLogitModel
 * MixedLogitModel
@@ -25,7 +27,8 @@ These are the state-of-the-art approaches implemented for the discrete choice se
 * RankNetDiscreteChoiceFunction
 * PairwiseSVMDiscreteChoiceFunction
 
-Check out our `interactive notebooks`_ to quickly find out what our package can do.
+Check out our `interactive notebooks`_ to quickly find out what our package can
+do.
 
 
 Getting started
@@ -41,8 +44,9 @@ As a simple "Hello World!"-example we will try to learn the Pareto problem:
                                    n_features=2)
    X_train, Y_train, X_test, Y_test = gen.get_single_train_test_split()
 
-All our learning algorithms are implemented using the scikit-learn estimator API.
-Fitting our FATENet architecture is as simple as calling the ``fit`` method:
+All our learning algorithms are implemented using the scikit-learn estimator
+API. Fitting our FATENet architecture is as simple as calling the ``fit``
+method:
 
 .. code-block:: python
 
@@ -69,8 +73,9 @@ Another option is to clone the repository and install CS-Rank using::
 
 Dependencies
 ------------
-CS-Rank depends on Tensorflow, Keras, NumPy, SciPy, matplotlib, scikit-learn, scikit-optimize, joblib and tqdm.
-For data processing and generation you will also need PyGMO, H5Py and pandas.
+CS-Rank depends on Tensorflow, Keras, NumPy, SciPy, matplotlib, scikit-learn,
+scikit-optimize, joblib and tqdm. For data processing and generation you will
+also need PyGMO, H5Py and pandas.
 
 Citing CS-Rank
 ----------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,4 +10,3 @@ API Reference
    api/objectranking
    api/choicefunction
    api/discretechoice
-   

--- a/docs/api/choicefunction.rst
+++ b/docs/api/choicefunction.rst
@@ -11,7 +11,7 @@ Choice Functions
    RankNetChoiceFunction
    GeneralizedLinearModel
    PairwiseSVMChoiceFunction
-   
+
 
 .. automodule:: csrank.choicefunctions
    :members: FATEChoiceFunction, FETAChoiceFunction, CmpNetChoiceFunction, RankNetChoiceFunction, GeneralizedLinearModel, PairwiseSVMChoiceFunction

--- a/docs/api/objectranking.rst
+++ b/docs/api/objectranking.rst
@@ -4,7 +4,7 @@ Object Ranking
 
 .. currentmodule:: csrank.objectranking
 .. autosummary::
-   
+
    FATEObjectRanker
    FETAObjectRanker
    CmpNet

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -5,7 +5,8 @@
 ************
 Introduction
 ************
-CS-Rank is a Python package for context-sensitive ranking and choice algorithms.
+CS-Rank is a Python package for context-sensitive ranking and choice
+algorithms.
 
 We implement the following new object ranking/choice architectures:
 
@@ -18,7 +19,8 @@ In addition, we also implement these algorithms for choice functions:
 * GeneralizedLinearModel
 * PairwiseSVMChoiceFunction
 
-These are the state-of-the-art approaches implemented for the discrete choice setting:
+These are the state-of-the-art approaches implemented for the discrete choice
+setting:
 
 * GeneralizedNestedLogitModel
 * MixedLogitModel
@@ -27,7 +29,8 @@ These are the state-of-the-art approaches implemented for the discrete choice se
 * RankNetDiscreteChoiceFunction
 * PairwiseSVMDiscreteChoiceFunction
 
-Check out our `interactive notebooks`_ to quickly find out what our package can do.
+Check out our `interactive notebooks`_ to quickly find out what our package can
+do.
 
 
 Getting started
@@ -42,8 +45,9 @@ As a simple "Hello World!"-example we will try to learn the Pareto problem:
                                    n_objects=30,
                                    n_features=2)
    X_train, Y_train, X_test, Y_test = gen.get_single_train_test_split()                     
-All our learning algorithms are implemented using the scikit-learn estimator API.
-Fitting our FATENet architecture is as simple as calling the ``fit`` method:
+All our learning algorithms are implemented using the scikit-learn estimator
+API. Fitting our FATENet architecture is as simple as calling the ``fit``
+method:
 
 .. code-block:: python
 
@@ -70,8 +74,9 @@ Another option is to clone the repository and install CS-Rank using::
 
 Dependencies
 ------------
-CS-Rank depends on Tensorflow, Keras, NumPy, SciPy, matplotlib, scikit-learn, scikit-optimize, joblib and tqdm.
-For data processing and generation you will also need PyGMO, H5Py and pandas.
+CS-Rank depends on Tensorflow, Keras, NumPy, SciPy, matplotlib, scikit-learn,
+scikit-optimize, joblib and tqdm. For data processing and generation you will
+also need PyGMO, H5Py and pandas.
 
 
 Citing CS-Rank

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -45,6 +45,7 @@ As a simple "Hello World!"-example we will try to learn the Pareto problem:
                                    n_objects=30,
                                    n_features=2)
    X_train, Y_train, X_test, Y_test = gen.get_single_train_test_split()
+
 All our learning algorithms are implemented using the scikit-learn estimator
 API. Fitting our FATENet architecture is as simple as calling the ``fit``
 method:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -11,8 +11,8 @@ algorithms.
 We implement the following new object ranking/choice architectures:
 
 * FATE (First aggregate then evaluate)
-* FETA (First evaluate then aggregate)   
- 
+* FETA (First evaluate then aggregate)
+
 In addition, we also implement these algorithms for choice functions:
 
 * RankNetChoiceFunction
@@ -44,7 +44,7 @@ As a simple "Hello World!"-example we will try to learn the Pareto problem:
    gen = ChoiceDatasetGenerator(dataset_type='pareto',
                                    n_objects=30,
                                    n_features=2)
-   X_train, Y_train, X_test, Y_test = gen.get_single_train_test_split()                     
+   X_train, Y_train, X_test, Y_test = gen.get_single_train_test_split()
 All our learning algorithms are implemented using the scikit-learn estimator
 API. Fitting our FATENet architecture is as simple as calling the ``fit``
 method:
@@ -52,7 +52,7 @@ method:
 .. code-block:: python
 
    fate = cs.FATEChoiceFunction(n_object_features=2)
-   fate.fit(X_train, Y_train) 
+   fate.fit(X_train, Y_train)
 
 Predictions can then be obtained using:
 


### PR DESCRIPTION
## Description

This fixes all the style issues and mistakes reported by `doc8` and registers `doc8` as a pre-commit hook (which will also be enforced by travis) to make sure the docs stay "clean".

## Motivation and Context

There were two mistakes, one of which @kiudee [noticed](https://github.com/kiudee/cs-ranking/pull/106#discussion_r398800124) previously. The other one was an anonymous link I forgot to specify in `CONTRIBUTING.rst`.

Catching those errors is undeniably valuable. The style-checking is opinionated and could be argued, but I think having a uniform style is very valuable as well.

## How Has This Been Tested?

Ran `doc8`, this PR.

## Does this close/impact existing issues?

Closes #103.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
