### PR TITLE
Determine data dimensions lazily on fit instead on init

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ method:
 
 .. code-block:: python
 
-   fate = cs.FATEChoiceFunction(n_object_features=2)
+   fate = cs.FATEChoiceFunction()
    fate.fit(X_train, Y_train)
 
 Predictions can then be obtained using:

--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -12,7 +12,6 @@ from csrank.core.cmpnet_core import CmpNetCore
 class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
     def __init__(
         self,
-        n_object_features,
         n_hidden=2,
         n_units=8,
         loss_function="binary_crossentropy",
@@ -49,8 +48,6 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
 
             Parameters
             ----------
-            n_object_features : int
-                Number of features of the object space
             n_hidden : int
                 Number of hidden layers used in the scoring network
             n_units : int
@@ -80,7 +77,6 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
 
         """
         super().__init__(
-            n_object_features=n_object_features,
             n_hidden=n_hidden,
             n_units=n_units,
             loss_function=loss_function,
@@ -95,11 +91,7 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
             **kwargs
         )
         self.logger = logging.getLogger(CmpNetChoiceFunction.__name__)
-        self.logger.info(
-            "Initializing network with object features {}".format(
-                self.n_object_features
-            )
-        )
+        self.logger.info("Initializing network")
         self.threshold = 0.5
 
     def _convert_instances_(self, X, Y):

--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -13,7 +13,6 @@ from .choice_functions import ChoiceFunctions
 class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
     def __init__(
         self,
-        n_object_features,
         n_hidden_set_layers=2,
         n_hidden_set_units=2,
         n_hidden_joint_layers=32,
@@ -50,8 +49,6 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
 
             Parameters
             ----------
-            n_object_features : int
-                Dimensionality of the feature space of each object
             n_hidden_set_layers : int
                 Number of set layers.
             n_hidden_set_units : int
@@ -82,7 +79,6 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
         self.loss_function = loss_function
         self.metrics = metrics
         super().__init__(
-            n_object_features=n_object_features,
             n_hidden_set_layers=n_hidden_set_layers,
             n_hidden_set_units=n_hidden_set_units,
             n_hidden_joint_layers=n_hidden_joint_layers,

--- a/csrank/choicefunction/fatelinear_choice.py
+++ b/csrank/choicefunction/fatelinear_choice.py
@@ -10,8 +10,6 @@ from .choice_functions import ChoiceFunctions
 class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
     def __init__(
         self,
-        n_object_features,
-        n_objects,
         n_hidden_set_units=2,
         loss_function=binary_crossentropy,
         learning_rate=1e-3,
@@ -41,10 +39,6 @@ class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
 
             Parameters
             ----------
-            n_object_features : int
-                Dimensionality of the feature space of each object
-            n_objects : int
-                Number of objects in each choice set
             n_hidden_set_units : int
                 Number of hidden set units.
             batch_size : int
@@ -57,8 +51,6 @@ class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
                 Keyword arguments for the @FATENetwork
         """
         super().__init__(
-            n_object_features=n_object_features,
-            n_objects=n_objects,
             n_hidden_set_units=n_hidden_set_units,
             learning_rate=learning_rate,
             batch_size=batch_size,

--- a/csrank/choicefunction/fetalinear_choice.py
+++ b/csrank/choicefunction/fetalinear_choice.py
@@ -10,8 +10,6 @@ from .choice_functions import ChoiceFunctions
 class FETALinearChoiceFunction(FETALinearCore, ChoiceFunctions):
     def __init__(
         self,
-        n_object_features,
-        n_objects,
         loss_function=binary_crossentropy,
         learning_rate=5e-3,
         batch_size=256,
@@ -40,10 +38,6 @@ class FETALinearChoiceFunction(FETALinearCore, ChoiceFunctions):
 
             Parameters
             ----------
-            n_object_features : int
-                Dimensionality of the feature space of each object
-            n_objects : int
-                Number of objects in each choice set
             n_hidden_set_units : int
                 Number of hidden set units.
             batch_size : int
@@ -56,8 +50,6 @@ class FETALinearChoiceFunction(FETALinearCore, ChoiceFunctions):
                 Keyword arguments for the @FATENetwork
         """
         super().__init__(
-            n_object_features=n_object_features,
-            n_objects=n_objects,
             learning_rate=learning_rate,
             batch_size=batch_size,
             loss_function=loss_function,

--- a/csrank/choicefunction/pairwise_choice.py
+++ b/csrank/choicefunction/pairwise_choice.py
@@ -10,7 +10,6 @@ from .util import generate_complete_pairwise_dataset
 class PairwiseSVMChoiceFunction(PairwiseSVM, ChoiceFunctions):
     def __init__(
         self,
-        n_object_features,
         C=1.0,
         tol=1e-4,
         normalize=True,
@@ -30,8 +29,6 @@ class PairwiseSVMChoiceFunction(PairwiseSVM, ChoiceFunctions):
 
             Parameters
             ----------
-            n_object_features : int
-                Number of features of the object space
             C : float, optional
                 Penalty parameter of the error term
             tol : float, optional
@@ -54,7 +51,6 @@ class PairwiseSVMChoiceFunction(PairwiseSVM, ChoiceFunctions):
 
         """
         super().__init__(
-            n_object_features=n_object_features,
             C=C,
             tol=tol,
             normalize=normalize,
@@ -63,11 +59,7 @@ class PairwiseSVMChoiceFunction(PairwiseSVM, ChoiceFunctions):
             **kwargs
         )
         self.logger = logging.getLogger(PairwiseSVMChoiceFunction.__name__)
-        self.logger.info(
-            "Initializing network with object features {}".format(
-                self.n_object_features
-            )
-        )
+        self.logger.info("Initializing network")
         self.threshold = 0.5
 
     def _convert_instances_(self, X, Y):
@@ -80,7 +72,7 @@ class PairwiseSVMChoiceFunction(PairwiseSVM, ChoiceFunctions):
             y_single,
         ) = generate_complete_pairwise_dataset(X, Y)
         del garbage
-        assert x_train.shape[1] == self.n_object_features
+        assert x_train.shape[1] == self.n_object_features_fit_
         self.logger.debug(
             "Finished the Dataset with instances {}".format(x_train.shape[0])
         )
@@ -107,6 +99,7 @@ class PairwiseSVMChoiceFunction(PairwiseSVM, ChoiceFunctions):
                 Keyword arguments for the fit function
 
         """
+        _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
                 X, Y, test_size=tune_size, random_state=self.random_state

--- a/csrank/choicefunction/ranknet_choice.py
+++ b/csrank/choicefunction/ranknet_choice.py
@@ -12,7 +12,6 @@ from .util import generate_complete_pairwise_dataset
 class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
     def __init__(
         self,
-        n_object_features,
         n_hidden=2,
         n_units=8,
         loss_function="binary_crossentropy",
@@ -40,8 +39,6 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
 
             Parameters
             ----------
-            n_object_features : int
-                Number of features of the object space
             n_hidden : int
                 Number of hidden layers used in the scoring network
             n_units : int
@@ -74,7 +71,6 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
                 [2] Burges, C. J. (2010). "From ranknet to lambdarank to lambdamart: An overview.", Learning, 11(23-581).
         """
         super().__init__(
-            n_object_features=n_object_features,
             n_hidden=n_hidden,
             n_units=n_units,
             loss_function=loss_function,
@@ -89,11 +85,7 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
             **kwargs
         )
         self.logger = logging.getLogger(RankNetChoiceFunction.__name__)
-        self.logger.info(
-            "Initializing network with object features {}".format(
-                self.n_object_features
-            )
-        )
+        self.logger.info("Initializing network")
         self.threshold = 0.5
 
     def construct_model(self):

--- a/csrank/core/feta_linear.py
+++ b/csrank/core/feta_linear.py
@@ -15,8 +15,6 @@ from csrank.util import progress_bar
 class FETALinearCore(Learner):
     def __init__(
         self,
-        n_object_features,
-        n_objects,
         learning_rate=1e-3,
         batch_size=256,
         loss_function=binary_crossentropy,
@@ -28,9 +26,7 @@ class FETALinearCore(Learner):
         self.learning_rate = learning_rate
         self.batch_size = batch_size
         self.random_state = random_state
-        self.n_object_features = n_object_features
         self.loss_function = loss_function
-        self.n_objects = n_objects
         self.epochs_drop = epochs_drop
         self.drop = drop
         self.current_lr = None
@@ -43,20 +39,24 @@ class FETALinearCore(Learner):
         self.W_last = None
 
     def _construct_model_(self, n_objects):
-        self.X = tf.placeholder("float32", [None, n_objects, self.n_object_features])
+        self.X = tf.placeholder(
+            "float32", [None, n_objects, self.n_object_features_fit_]
+        )
         self.Y = tf.placeholder("float32", [None, n_objects])
-        std = 1 / np.sqrt(self.n_object_features)
+        std = 1 / np.sqrt(self.n_object_features_fit_)
         self.b1 = tf.Variable(
             self.random_state_.normal(loc=0, scale=std, size=1), dtype=tf.float32
         )
         self.W1 = tf.Variable(
             self.random_state_.normal(
-                loc=0, scale=std, size=2 * self.n_object_features
+                loc=0, scale=std, size=2 * self.n_object_features_fit_
             ),
             dtype=tf.float32,
         )
         self.W2 = tf.Variable(
-            self.random_state_.normal(loc=0, scale=std, size=self.n_object_features),
+            self.random_state_.normal(
+                loc=0, scale=std, size=self.n_object_features_fit_
+            ),
             dtype=tf.float32,
         )
         self.b2 = tf.Variable(
@@ -101,9 +101,8 @@ class FETALinearCore(Learner):
     ):
         self.random_state_ = check_random_state(self.random_state)
         # Global Variables Initializer
-        n_instances, n_objects, n_features = X.shape
-        assert n_features == self.n_object_features
-        self._construct_model_(n_objects)
+        n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
+        self._construct_model_(self.n_objects_fit_)
         init = tf.global_variables_initializer()
 
         with tf.Session() as tf_session:
@@ -148,7 +147,7 @@ class FETALinearCore(Learner):
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_instances, n_objects, n_features = X.shape
-        assert n_features == self.n_object_features
+        assert n_features == self.n_object_features_fit_
         outputs = [list() for _ in range(n_objects)]
         for i, j in combinations(range(n_objects), 2):
             x1 = X[:, i]

--- a/csrank/core/pairwise_svm.py
+++ b/csrank/core/pairwise_svm.py
@@ -13,7 +13,6 @@ from csrank.util import print_dictionary
 class PairwiseSVM(Learner):
     def __init__(
         self,
-        n_object_features,
         C=1.0,
         tol=1e-4,
         normalize=True,
@@ -25,8 +24,6 @@ class PairwiseSVM(Learner):
 
         Parameters
         ----------
-        n_object_features : int
-            Number of features of the object space
         C : float, optional
             Penalty parameter of the error term
         tol : float, optional
@@ -45,7 +42,6 @@ class PairwiseSVM(Learner):
             [1] Joachims, T. (2002, July). "Optimizing search engines using clickthrough data.", Proceedings of the eighth ACM SIGKDD international conference on Knowledge discovery and data mining (pp. 133-142). ACM.
         """
         self.normalize = normalize
-        self.n_object_features = n_object_features
         self.C = C
         self.tol = tol
         self.logger = logging.getLogger("RankSVM")
@@ -71,6 +67,7 @@ class PairwiseSVM(Learner):
 
         """
         self.random_state_ = check_random_state(self.random_state)
+        _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         x_train, y_single = self._convert_instances_(X, Y)
         if x_train.shape[0] > self.threshold_instances:
             self.model = LogisticRegression(
@@ -101,7 +98,7 @@ class PairwiseSVM(Learner):
         self.logger.debug("Fitting Complete")
 
     def _predict_scores_fixed(self, X, **kwargs):
-        assert X.shape[-1] == self.n_object_features
+        assert X.shape[-1] == self.n_object_features_fit_
         self.logger.info(
             "For Test instances {} objects {} features {}".format(*X.shape)
         )

--- a/csrank/discretechoice/cmpnet_discrete_choice.py
+++ b/csrank/discretechoice/cmpnet_discrete_choice.py
@@ -11,7 +11,6 @@ from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
     def __init__(
         self,
-        n_object_features,
         n_hidden=2,
         n_units=8,
         loss_function="binary_crossentropy",
@@ -46,8 +45,6 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
 
             Parameters
             ----------
-            n_object_features : int
-                Number of features of the object space
             n_hidden : int
                 Number of hidden layers used in the scoring network
             n_units : int
@@ -78,7 +75,6 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
                 [1] Leonardo Rigutini, Tiziano Papini, Marco Maggini, and Franco Scarselli. 2011. SortNet: Learning to Rank by a Neural Preference Function. IEEE Trans. Neural Networks 22, 9 (2011), 1368–1380. https://doi.org/10.1109/TNN.2011.2160875
         """
         super().__init__(
-            n_object_features=n_object_features,
             n_hidden=n_hidden,
             n_units=n_units,
             loss_function=loss_function,
@@ -93,11 +89,7 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
             **kwargs
         )
         self.logger = logging.getLogger(CmpNetDiscreteChoiceFunction.__name__)
-        self.logger.info(
-            "Initializing network with object features {}".format(
-                self.n_object_features
-            )
-        )
+        self.logger.info("Initializing network")
 
     def _convert_instances_(self, X, Y):
         self.logger.debug("Creating the Dataset")

--- a/csrank/discretechoice/fate_discrete_choice.py
+++ b/csrank/discretechoice/fate_discrete_choice.py
@@ -11,7 +11,6 @@ from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
     def __init__(
         self,
-        n_object_features,
         n_hidden_set_layers=2,
         n_hidden_set_units=2,
         loss_function="categorical_hinge",
@@ -48,8 +47,6 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
 
             Parameters
             ----------
-            n_object_features : int
-                Dimensionality of the feature space of each object
             n_hidden_set_layers : int
                 Number of set layers.
             n_hidden_set_units : int
@@ -80,7 +77,6 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
         self.loss_function = loss_function
         self.metrics = metrics
         super().__init__(
-            n_object_features=n_object_features,
             n_hidden_set_layers=n_hidden_set_layers,
             n_hidden_set_units=n_hidden_set_units,
             n_hidden_joint_layers=n_hidden_joint_layers,

--- a/csrank/discretechoice/fatelinear_discrete_choice.py
+++ b/csrank/discretechoice/fatelinear_discrete_choice.py
@@ -9,8 +9,6 @@ from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 class FATELinearDiscreteChoiceFunction(FATELinearCore, DiscreteObjectChooser):
     def __init__(
         self,
-        n_object_features,
-        n_objects,
         n_hidden_set_units=2,
         loss_function=categorical_hinge,
         learning_rate=1e-3,
@@ -40,10 +38,6 @@ class FATELinearDiscreteChoiceFunction(FATELinearCore, DiscreteObjectChooser):
 
             Parameters
             ----------
-            n_object_features : int
-                Dimensionality of the feature space of each object
-            n_objects : int
-                Number of objects in each choice set
             n_hidden_set_units : int
                 Number of hidden set units.
             batch_size : int
@@ -56,8 +50,6 @@ class FATELinearDiscreteChoiceFunction(FATELinearCore, DiscreteObjectChooser):
                 Keyword arguments for the @FATENetwork
         """
         super().__init__(
-            n_object_features=n_object_features,
-            n_objects=n_objects,
             n_hidden_set_units=n_hidden_set_units,
             learning_rate=learning_rate,
             batch_size=batch_size,

--- a/csrank/discretechoice/fetalinear_discrete_choice.py
+++ b/csrank/discretechoice/fetalinear_discrete_choice.py
@@ -9,8 +9,6 @@ from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 class FETALinearDiscreteChoiceFunction(FETALinearCore, DiscreteObjectChooser):
     def __init__(
         self,
-        n_object_features,
-        n_objects,
         loss_function=categorical_hinge,
         learning_rate=5e-3,
         batch_size=256,
@@ -39,10 +37,6 @@ class FETALinearDiscreteChoiceFunction(FETALinearCore, DiscreteObjectChooser):
 
             Parameters
             ----------
-            n_object_features : int
-                Dimensionality of the feature space of each object
-            n_objects : int
-                Number of objects in each choice set
             n_hidden_set_units : int
                 Number of hidden set units.
             batch_size : int
@@ -55,8 +49,6 @@ class FETALinearDiscreteChoiceFunction(FETALinearCore, DiscreteObjectChooser):
                 Keyword arguments for the @FATENetwork
         """
         super().__init__(
-            n_object_features=n_object_features,
-            n_objects=n_objects,
             learning_rate=learning_rate,
             batch_size=batch_size,
             loss_function=loss_function,

--- a/csrank/discretechoice/pairwise_discrete_choice.py
+++ b/csrank/discretechoice/pairwise_discrete_choice.py
@@ -8,7 +8,6 @@ from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 class PairwiseSVMDiscreteChoiceFunction(PairwiseSVM, DiscreteObjectChooser):
     def __init__(
         self,
-        n_object_features,
         C=1.0,
         tol=1e-4,
         normalize=True,
@@ -28,8 +27,6 @@ class PairwiseSVMDiscreteChoiceFunction(PairwiseSVM, DiscreteObjectChooser):
 
             Parameters
             ----------
-            n_object_features : int
-                Number of features of the object space
             C : float, optional
                 Penalty parameter of the error term
             tol : float, optional
@@ -51,7 +48,6 @@ class PairwiseSVMDiscreteChoiceFunction(PairwiseSVM, DiscreteObjectChooser):
                 [2] Sebastián Maldonado, Ricardo Montoya, and Richard Weber. „Advanced conjoint analysis using feature selection via support vector machines“. In: European Journal of Operational Research 241.2 (2015), pp. 564 –574.
         """
         super().__init__(
-            n_object_features=n_object_features,
             C=C,
             tol=tol,
             normalize=normalize,
@@ -60,11 +56,7 @@ class PairwiseSVMDiscreteChoiceFunction(PairwiseSVM, DiscreteObjectChooser):
             **kwargs
         )
         self.logger = logging.getLogger(PairwiseSVMDiscreteChoiceFunction.__name__)
-        self.logger.info(
-            "Initializing network with object features {}".format(
-                self.n_object_features
-            )
-        )
+        self.logger.info("Initializing network")
 
     def _convert_instances_(self, X, Y):
         self.logger.debug("Creating the Dataset")
@@ -76,13 +68,14 @@ class PairwiseSVMDiscreteChoiceFunction(PairwiseSVM, DiscreteObjectChooser):
             y_single,
         ) = generate_complete_pairwise_dataset(X, Y)
         del garbage
-        assert x_train.shape[1] == self.n_object_features
+        assert x_train.shape[1] == self.n_object_features_fit_
         self.logger.debug(
             "Finished the Dataset with instances {}".format(x_train.shape[0])
         )
         return x_train, y_single
 
     def fit(self, X, Y, **kwd):
+        _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         super().fit(X, Y, **kwd)
 
     def _predict_scores_fixed(self, X, **kwargs):

--- a/csrank/discretechoice/ranknet_discrete_choice.py
+++ b/csrank/discretechoice/ranknet_discrete_choice.py
@@ -11,7 +11,6 @@ from .discrete_choice import DiscreteObjectChooser
 class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
     def __init__(
         self,
-        n_object_features,
         n_hidden=2,
         n_units=8,
         loss_function="binary_crossentropy",
@@ -40,8 +39,6 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
 
             Parameters
             ----------
-            n_object_features : int
-                Number of features of the object space
             n_hidden : int
                 Number of hidden layers used in the scoring network
             n_units : int
@@ -74,7 +71,6 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
                 [2] Burges, C. J. (2010). "From ranknet to lambdarank to lambdamart: An overview.", Learning, 11(23-581).
         """
         super().__init__(
-            n_object_features=n_object_features,
             n_hidden=n_hidden,
             n_units=n_units,
             loss_function=loss_function,
@@ -89,11 +85,7 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
             **kwargs
         )
         self.logger = logging.getLogger(RankNetDiscreteChoiceFunction.__name__)
-        self.logger.info(
-            "Initializing network with object features {}".format(
-                self.n_object_features
-            )
-        )
+        self.logger.info("Initializing network")
 
     def construct_model(self):
         return super().construct_model()

--- a/csrank/objectranking/cmp_net.py
+++ b/csrank/objectranking/cmp_net.py
@@ -13,7 +13,6 @@ __all__ = ["CmpNet"]
 class CmpNet(CmpNetCore, ObjectRanker):
     def __init__(
         self,
-        n_object_features,
         n_hidden=2,
         n_units=8,
         loss_function="binary_crossentropy",
@@ -50,8 +49,6 @@ class CmpNet(CmpNetCore, ObjectRanker):
 
            Parameters
            ----------
-           n_object_features : int
-               Number of features of the object space
            n_hidden : int
                Number of hidden layers used in the scoring network
            n_units : int
@@ -83,7 +80,6 @@ class CmpNet(CmpNetCore, ObjectRanker):
                 [1] Leonardo Rigutini, Tiziano Papini, Marco Maggini, and Franco Scarselli. 2011. SortNet: Learning to Rank by a Neural Preference Function. IEEE Trans. Neural Networks 22, 9 (2011), 1368–1380. https://doi.org/10.1109/TNN.2011.2160875
         """
         super().__init__(
-            n_object_features=n_object_features,
             n_hidden=n_hidden,
             n_units=n_units,
             loss_function=loss_function,
@@ -98,11 +94,7 @@ class CmpNet(CmpNetCore, ObjectRanker):
             **kwargs
         )
         self.logger = logging.getLogger(CmpNet.__name__)
-        self.logger.info(
-            "Initializing network with object features {}".format(
-                self.n_object_features
-            )
-        )
+        self.logger.info("Initializing network")
 
     def _convert_instances_(self, X, Y):
         self.logger.debug("Creating the Dataset")

--- a/csrank/objectranking/expected_rank_regression.py
+++ b/csrank/objectranking/expected_rank_regression.py
@@ -18,7 +18,6 @@ __all__ = ["ExpectedRankRegression"]
 class ExpectedRankRegression(ObjectRanker, Learner):
     def __init__(
         self,
-        n_object_features,
         alpha=0.0,
         l1_ratio=0.5,
         tol=1e-4,
@@ -46,8 +45,6 @@ class ExpectedRankRegression(ObjectRanker, Learner):
 
             Parameters
             ----------
-            n_object_features : int
-                Number of features of the object space
             alpha : float, optional
                 Regularization strength
             l1_ratio : float, optional
@@ -68,7 +65,6 @@ class ExpectedRankRegression(ObjectRanker, Learner):
                 [1] Kamishima, T., Kazawa, H., & Akaho, S. (2005, November). "Supervised ordering-an empirical survey.", Fifth IEEE International Conference on Data Mining.
         """
         self.normalize = normalize
-        self.n_object_features = n_object_features
         self.alpha = alpha
         self.l1_ratio = l1_ratio
         self.tol = tol
@@ -96,7 +92,6 @@ class ExpectedRankRegression(ObjectRanker, Learner):
         self.random_state_ = check_random_state(self.random_state)
         self.logger.debug("Creating the Dataset")
         x_train, y_train = complete_linear_regression_dataset(X, Y)
-        assert x_train.shape[1] == self.n_object_features
         self.logger.debug("Finished the Dataset")
         if self.alpha < 1e-3:
             self.model = LinearRegression(

--- a/csrank/objectranking/fate_object_ranker.py
+++ b/csrank/objectranking/fate_object_ranker.py
@@ -12,7 +12,6 @@ from csrank.objectranking.object_ranker import ObjectRanker
 class FATEObjectRanker(FATENetwork, ObjectRanker):
     def __init__(
         self,
-        n_object_features,
         n_hidden_set_layers=2,
         n_hidden_set_units=2,
         n_hidden_joint_layers=32,
@@ -48,8 +47,6 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
 
             Parameters
             ----------
-            n_object_features : int
-                Dimensionality of the feature space of each object
             n_hidden_set_layers : int
                 Number of set layers.
             n_hidden_set_units : int
@@ -80,7 +77,6 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
         self.loss_function = loss_function
         self.metrics = metrics
         super().__init__(
-            n_object_features=n_object_features,
             n_hidden_set_layers=n_hidden_set_layers,
             n_hidden_set_units=n_hidden_set_units,
             n_hidden_joint_layers=n_hidden_joint_layers,

--- a/csrank/objectranking/fatelinear_object_ranker.py
+++ b/csrank/objectranking/fatelinear_object_ranker.py
@@ -8,8 +8,6 @@ from .object_ranker import ObjectRanker
 class FATELinearObjectRanker(FATELinearCore, ObjectRanker):
     def __init__(
         self,
-        n_object_features,
-        n_objects,
         n_hidden_set_units=2,
         loss_function=hinged_rank_loss,
         learning_rate=1e-3,
@@ -39,10 +37,6 @@ class FATELinearObjectRanker(FATELinearCore, ObjectRanker):
 
             Parameters
             ----------
-            n_object_features : int
-                Dimensionality of the feature space of each object
-            n_objects : int
-                Number of objects in each choice set
             n_hidden_set_units : int
                 Number of hidden set units.
             batch_size : int
@@ -55,8 +49,6 @@ class FATELinearObjectRanker(FATELinearCore, ObjectRanker):
                 Keyword arguments for the @FATENetwork
         """
         super().__init__(
-            n_object_features=n_object_features,
-            n_objects=n_objects,
             n_hidden_set_units=n_hidden_set_units,
             learning_rate=learning_rate,
             batch_size=batch_size,

--- a/csrank/objectranking/feta_object_ranker.py
+++ b/csrank/objectranking/feta_object_ranker.py
@@ -13,8 +13,6 @@ __all__ = ["FETAObjectRanker"]
 class FETAObjectRanker(FETANetwork, ObjectRanker):
     def __init__(
         self,
-        n_objects,
-        n_object_features,
         n_hidden=2,
         n_units=8,
         add_zeroth_order_model=False,
@@ -49,10 +47,6 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
 
             Parameters
             ----------
-            n_objects : int
-                Number of objects to be ranked
-            n_object_features : int
-                Dimensionality of the feature space of each object
             n_hidden : int
                 Number of hidden layers
             n_units : int
@@ -85,8 +79,6 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
                 Keyword arguments for the hidden units
         """
         super().__init__(
-            n_objects=n_objects,
-            n_object_features=n_object_features,
             n_hidden=n_hidden,
             n_units=n_units,
             add_zeroth_order_model=add_zeroth_order_model,

--- a/csrank/objectranking/fetalinear_object_ranker.py
+++ b/csrank/objectranking/fetalinear_object_ranker.py
@@ -8,8 +8,6 @@ from .object_ranker import ObjectRanker
 class FETALinearObjectRanker(FETALinearCore, ObjectRanker):
     def __init__(
         self,
-        n_object_features,
-        n_objects,
         loss_function=hinged_rank_loss,
         learning_rate=5e-3,
         batch_size=256,
@@ -38,10 +36,6 @@ class FETALinearObjectRanker(FETALinearCore, ObjectRanker):
 
             Parameters
             ----------
-            n_object_features : int
-                Dimensionality of the feature space of each object
-            n_objects : int
-                Number of objects in each choice set
             n_hidden_set_units : int
                 Number of hidden set units.
             batch_size : int
@@ -54,8 +48,6 @@ class FETALinearObjectRanker(FETALinearCore, ObjectRanker):
                 Keyword arguments for the @FATENetwork
         """
         super().__init__(
-            n_object_features=n_object_features,
-            n_objects=n_objects,
             learning_rate=learning_rate,
             batch_size=batch_size,
             loss_function=loss_function,

--- a/csrank/objectranking/rank_net.py
+++ b/csrank/objectranking/rank_net.py
@@ -13,7 +13,6 @@ __all__ = ["RankNet"]
 class RankNet(RankNetCore, ObjectRanker):
     def __init__(
         self,
-        n_object_features,
         n_hidden=2,
         n_units=8,
         loss_function="binary_crossentropy",
@@ -40,8 +39,6 @@ class RankNet(RankNetCore, ObjectRanker):
 
             Parameters
             ----------
-            n_object_features : int
-                Number of features of the object space
             n_hidden : int
                 Number of hidden layers used in the scoring network
             n_units : int
@@ -76,7 +73,6 @@ class RankNet(RankNetCore, ObjectRanker):
 
         """
         super().__init__(
-            n_object_features=n_object_features,
             n_hidden=n_hidden,
             n_units=n_units,
             loss_function=loss_function,
@@ -91,11 +87,7 @@ class RankNet(RankNetCore, ObjectRanker):
             **kwargs
         )
         self.logger = logging.getLogger(RankNet.__name__)
-        self.logger.info(
-            "Initializing network with object features {}".format(
-                self.n_object_features
-            )
-        )
+        self.logger.info("Initializing network")
 
     def construct_model(self):
         return super().construct_model()

--- a/csrank/objectranking/rank_svm.py
+++ b/csrank/objectranking/rank_svm.py
@@ -10,7 +10,6 @@ __all__ = ["RankSVM"]
 class RankSVM(ObjectRanker, PairwiseSVM):
     def __init__(
         self,
-        n_object_features,
         C=1.0,
         tol=1e-4,
         normalize=True,
@@ -30,8 +29,6 @@ class RankSVM(ObjectRanker, PairwiseSVM):
 
             Parameters
             ----------
-            n_object_features : int
-                Number of features of the object space
             C : float, optional
                 Penalty parameter of the error term
             tol : float, optional
@@ -50,7 +47,6 @@ class RankSVM(ObjectRanker, PairwiseSVM):
                 [1] Joachims, T. (2002, July). "Optimizing search engines using clickthrough data.", Proceedings of the eighth ACM SIGKDD international conference on Knowledge discovery and data mining (pp. 133-142). ACM.
         """
         super().__init__(
-            n_object_features=n_object_features,
             C=C,
             tol=tol,
             normalize=normalize,
@@ -59,13 +55,10 @@ class RankSVM(ObjectRanker, PairwiseSVM):
             **kwargs
         )
         self.logger = logging.getLogger(RankSVM.__name__)
-        self.logger.info(
-            "Initializing network with object features {}".format(
-                self.n_object_features
-            )
-        )
+        self.logger.info("Initializing network")
 
     def fit(self, X, Y, **kwargs):
+        _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         super().fit(X, Y, **kwargs)
 
     def _convert_instances_(self, X, Y):
@@ -78,7 +71,7 @@ class RankSVM(ObjectRanker, PairwiseSVM):
             y_single,
         ) = generate_complete_pairwise_dataset(X, Y)
         del garbage
-        assert x_train.shape[1] == self.n_object_features
+        assert x_train.shape[1] == self.n_object_features_fit_
         self.logger.debug(
             "Finished the Dataset with instances {}".format(x_train.shape[0])
         )

--- a/csrank/tests/test_choice_functions.py
+++ b/csrank/tests/test_choice_functions.py
@@ -92,7 +92,6 @@ def test_choice_function_fixed(trivial_choice_problem, name):
     x, y = trivial_choice_problem
     choice_function = choice_functions[name][0]
     params, accuracies = choice_functions[name][1], choice_functions[name][2]
-    params["n_objects"], params["n_object_features"] = tuple(x.shape[1:])
     learner = choice_function(**params)
     if name == GLM_CHOICE:
         learner.fit(

--- a/csrank/tests/test_discrete_choice.py
+++ b/csrank/tests/test_discrete_choice.py
@@ -100,7 +100,6 @@ def test_discrete_choice_function_fixed(trivial_discrete_choice_problem, name):
         discrete_choice_functions[name][1],
         discrete_choice_functions[name][2],
     )
-    params["n_objects"], params["n_object_features"] = tuple(x.shape[1:])
     learner = choice_function(**params)
     if name in [MNL, NLM, GEV, PCL, MLM]:
         learner.fit(

--- a/csrank/tests/test_fate.py
+++ b/csrank/tests/test_fate.py
@@ -32,7 +32,7 @@ def test_construction_core():
         def fit(self, *args, **kwargs):
             pass
 
-    grc = MockClass(n_objects=n_objects, n_features=n_features)
+    grc = MockClass()
     grc._construct_layers(
         activation=grc.activation,
         kernel_initializer=grc.kernel_initializer,
@@ -87,7 +87,6 @@ def test_fate_object_ranker_fixed_generator():
             yield x, y_true
 
     fate = FATEObjectRanker(
-        n_object_features=1,
         n_hidden_joint_layers=1,
         n_hidden_set_layers=1,
         n_hidden_joint_units=5,

--- a/csrank/tests/test_ranking.py
+++ b/csrank/tests/test_ranking.py
@@ -110,7 +110,6 @@ def test_object_ranker_fixed(trivial_ranking_problem, ranker_name):
     np.random.seed(123)
     x, y = trivial_ranking_problem
     ranker, params, (loss, acc) = object_rankers[ranker_name]
-    params["n_objects"], params["n_object_features"] = tuple(x.shape[1:])
     ranker = ranker(**params)
     if "linear" in ranker_name:
         ranker.fit(x, y, epochs=10, validation_split=0, verbose=False)

--- a/csrank/tests/test_ranking.py
+++ b/csrank/tests/test_ranking.py
@@ -70,8 +70,8 @@ def check_params_tunable(tunable_obj, params, rtol=1e-2, atol=1e-4):
                     isinstance(tunable_obj, PairedCombinatorialLogit)
                     and key == "n_nests"
                 ):
-                    tunable_obj.n_nests == tunable_obj.n_objects * (
-                        tunable_obj.n_objects - 1
+                    tunable_obj.n_nests == tunable_obj.n_objects_fit_ * (
+                        tunable_obj.n_objects_fit_ - 1
                     ) / 2
                 else:
                     assert np.isclose(

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -52,7 +52,7 @@ method:
 
 .. code-block:: python
 
-   fate = cs.FATEChoiceFunction(n_object_features=2)
+   fate = cs.FATEChoiceFunction()
    fate.fit(X_train, Y_train)
 
 Predictions can then be obtained using:

--- a/docs/notebooks/FATE-Net-DC.ipynb
+++ b/docs/notebooks/FATE-Net-DC.ipynb
@@ -139,7 +139,6 @@
     "from csrank import FATEObjectRanker\n",
     "from csrank.losses import smooth_rank_loss\n",
     "fate = FATEObjectRanker(\n",
-    "    n_object_features=n_features,\n",
     "    loss_function=smooth_rank_loss,\n",
     "    optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9))"
    ]

--- a/docs/notebooks/FATE-Net-Ranking.ipynb
+++ b/docs/notebooks/FATE-Net-Ranking.ipynb
@@ -131,7 +131,6 @@
     "from csrank import FATEObjectRanker\n",
     "from csrank.losses import smooth_rank_loss\n",
     "fate = FATEObjectRanker(\n",
-    "    n_object_features=n_features,\n",
     "    loss_function=smooth_rank_loss,\n",
     "    optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9))"
    ]

--- a/docs/notebooks/Rank-Net-Choice.ipynb
+++ b/docs/notebooks/Rank-Net-Choice.ipynb
@@ -124,7 +124,6 @@
    "outputs": [],
    "source": [
     "ranknet = RankNetChoiceFunction(\n",
-    "    n_object_features=n_features,\n",
     "    optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9))"
    ]
   },


### PR DESCRIPTION
## Description

Continuation of #94.

This is a work in progress. I'm putting this out there since it is likely I won't have any time left to finish it this week.

Things to do:
- ~Unify all the changes. Initially I started of by just inferring the data dimensionality from the current data without storing it in an instance attribute. This requires more invasive refactorings however, since it means the dimension will only be available from the `fit` function and the `fit` function has to pass it along as parameters. It doesn't always work either, since sometimes the dimensionality is needed at prediction time and then it sometimes matters if the dimensionality of the data we're predicting on is different from the dimensionality of the data we have trained on. Therefore I started storing the dimensionality the current model was fit on in instance attributes. I should adapt the earlier changes to this style to increase uniformity and reduce the chance of error.~
- ~Verify that pre-commit hooks and the full test suite pass after every commit.~
- ~Find all initializations in which the dimensionality is passed to the estimator. Currently this doesn't throw an error since the estimators accept `**kwargs`. Still, the calls should be adapted.~
- ~Double-check if any more documentation needs to be modified to remove references to `n_objects` and `n_object_features`.~

## Motivation and Context

 The `scikit-learn` estimator API only allows parameters with default values for `__init__`. There are no sensible defaults for the data dimension. Further, its just unnecessary to fix the data dimension on init. The developer experience is much nicer when it can simply be inferred from the data passed to `fit`.

## How Has This Been Tested?

Ran the full test suite.

## Does this close/impact existing issues?

Impacts #94, #116 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
