### PR TITLE
Require uninitialized optimizers for our learners

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,10 @@ Unreleased
   particular, the parameters nesterov, momentum and lr are now set to the
   default values set by keras.
 
+* All optimizers must now be passed in uninitialized. Optimizer parameters can
+  be set by passing `optimizer__{kwarg}` parameters to the learner. This
+  follows the scikit-learn and skorch standard.
+
 1.2.1 (2020-06-08)
 ------------------
 

--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -19,7 +19,7 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(),
+        optimizer=SGD,
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
@@ -60,8 +60,10 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
                 Regularizer function applied to all the hidden weight matrices.
             activation : function or string
                 Type of activation function to use in each hidden layer
-            optimizer : function or string
-                Optimizer to use during stochastic gradient descent
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             metrics : list
                 List of metrics to evaluate during training (can be non-differentiable)
             batch_size : int

--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -21,7 +21,7 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
         activation="selu",
         kernel_initializer="lecun_normal",
         kernel_regularizer=l2(0.01),
-        optimizer=SGD(),
+        optimizer=SGD,
         batch_size=256,
         metrics=None,
         random_state=None,
@@ -63,8 +63,10 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
                 Initialization function for the weights of each hidden layer
             kernel_regularizer : function or string
                 Regularizer to use in the hidden units
-            optimizer : string or function
-                Stochastic gradient optimizer
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             batch_size : int
                 Batch size to use for training
             loss_function : function

--- a/csrank/choicefunction/feta_choice.py
+++ b/csrank/choicefunction/feta_choice.py
@@ -34,7 +34,7 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="selu",
-        optimizer=SGD(),
+        optimizer=SGD,
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
@@ -79,8 +79,10 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
                 Initialization function for the weights of each hidden layer
             activation : string or function
                 Activation function to use in the hidden units
-            optimizer : string or function
-                Stochastic gradient optimizer
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             metrics : list
                 List of evaluation metrics (can be non-differentiable)
             batch_size : int
@@ -218,7 +220,7 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
         model = Model(inputs=self.input_layer, outputs=scores)
         self.logger.debug("Compiling complete model...")
         model.compile(
-            loss=self.loss_function, optimizer=self.optimizer, metrics=self.metrics
+            loss=self.loss_function, optimizer=self.optimizer_, metrics=self.metrics
         )
         return model
 

--- a/csrank/choicefunction/ranknet_choice.py
+++ b/csrank/choicefunction/ranknet_choice.py
@@ -19,7 +19,7 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(),
+        optimizer=SGD,
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
@@ -53,8 +53,10 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
                 Initialization function for the weights of each hidden layer
             activation : function or string
                 Type of activation function to use in each hidden layer
-            optimizer : function or string
-                Optimizer to use during stochastic gradient descent
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             metrics : list
                 List of metrics to evaluate during training (can be non-differentiable)
             batch_size : int

--- a/csrank/discretechoice/cmpnet_discrete_choice.py
+++ b/csrank/discretechoice/cmpnet_discrete_choice.py
@@ -18,7 +18,7 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(),
+        optimizer=SGD,
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
@@ -59,8 +59,10 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
                 Initialization function for the weights of each hidden layer
             activation : function or string
                 Type of activation function to use in each hidden layer
-            optimizer : function or string
-                Optimizer to use during stochastic gradient descent
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             metrics : list
                 List of metrics to evaluate during training (can be non-differentiable)
             batch_size : int

--- a/csrank/discretechoice/fate_discrete_choice.py
+++ b/csrank/discretechoice/fate_discrete_choice.py
@@ -20,7 +20,7 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
         activation="selu",
         kernel_initializer="lecun_normal",
         kernel_regularizer=l2(0.01),
-        optimizer=SGD(),
+        optimizer=SGD,
         batch_size=256,
         random_state=None,
         **kwargs,
@@ -61,8 +61,10 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
                 Initialization function for the weights of each hidden layer
             kernel_regularizer : function or string
                 Regularizer to use in the hidden units
-            optimizer : string or function
-                Stochastic gradient optimizer
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             batch_size : int
                 Batch size to use for training
             loss_function : function

--- a/csrank/discretechoice/feta_discrete_choice.py
+++ b/csrank/discretechoice/feta_discrete_choice.py
@@ -32,7 +32,7 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="selu",
-        optimizer=SGD(),
+        optimizer=SGD,
         metrics=["categorical_accuracy"],
         batch_size=256,
         random_state=None,
@@ -77,8 +77,10 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
                 Initialization function for the weights of each hidden layer
             activation : string or function
                 Activation function to use in the hidden units
-            optimizer : string or function
-                Stochastic gradient optimizer
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             metrics : list
                 List of evaluation metrics (can be non-differentiable)
             batch_size : int
@@ -262,7 +264,7 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
         model = Model(inputs=self.input_layer, outputs=scores)
         self.logger.debug("Compiling complete model...")
         model.compile(
-            loss=self.loss_function, optimizer=self.optimizer, metrics=self.metrics
+            loss=self.loss_function, optimizer=self.optimizer_, metrics=self.metrics
         )
         return model
 

--- a/csrank/discretechoice/ranknet_discrete_choice.py
+++ b/csrank/discretechoice/ranknet_discrete_choice.py
@@ -18,7 +18,7 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(),
+        optimizer=SGD,
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
@@ -53,8 +53,10 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
                 Initialization function for the weights of each hidden layer
             activation : function or string
                 Type of activation function to use in each hidden layer
-            optimizer : function or string
-                Optimizer to use during stochastic gradient descent
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             metrics : list
                 List of metrics to evaluate during training (can be non-differentiable)
             batch_size : int

--- a/csrank/learner.py
+++ b/csrank/learner.py
@@ -4,7 +4,21 @@ from abc import abstractmethod
 from csrank.tunable import Tunable
 
 
+def filter_dict_by_prefix(source, prefix):
+    result = dict()
+    for key in source.keys():
+        if key.startswith(prefix):
+            key_stripped = key[len(prefix) :]
+            result[key_stripped] = source[key]
+    return result
+
+
 class Learner(Tunable, metaclass=ABCMeta):
+    def _initialize_optimizer(self):
+        optimizer_params = filter_dict_by_prefix(self.__dict__, "optimizer__")
+        optimizer_params.update(filter_dict_by_prefix(self.kwargs, "optimizer__"))
+        self.optimizer_ = self.optimizer(**optimizer_params)
+
     @abstractmethod
     def fit(self, X, Y, **kwargs):
         """

--- a/csrank/objectranking/cmp_net.py
+++ b/csrank/objectranking/cmp_net.py
@@ -20,7 +20,7 @@ class CmpNet(CmpNetCore, ObjectRanker):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(),
+        optimizer=SGD,
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
@@ -62,8 +62,12 @@ class CmpNet(CmpNetCore, ObjectRanker):
                Regularizer function applied to all the hidden weight matrices.
            activation : function or string
                Type of activation function to use in each hidden layer
-           optimizer : function or string
-               Optimizer to use during stochastic gradient descent
+           optimizer: Class
+               Uninitialized optimizer class following the keras optimizer interface.
+           optimizer__{kwarg}
+               Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
+              descent. Must be a function without arguments that returns a
+              Keras optimizer.
            metrics : list
                List of metrics to evaluate during training (can be
                non-differentiable)

--- a/csrank/objectranking/fate_object_ranker.py
+++ b/csrank/objectranking/fate_object_ranker.py
@@ -19,7 +19,7 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
         activation="selu",
         kernel_initializer="lecun_normal",
         kernel_regularizer=l2(0.01),
-        optimizer=SGD(),
+        optimizer=SGD,
         batch_size=256,
         loss_function=hinged_rank_loss,
         metrics=[zero_one_rank_loss_for_scores_ties],
@@ -61,8 +61,10 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
                 Initialization function for the weights of each hidden layer
             kernel_regularizer : function or string
                 Regularizer to use in the hidden units
-            optimizer : string or function
-                Stochastic gradient optimizer
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             batch_size : int
                 Batch size to use for training
             loss_function : function

--- a/csrank/objectranking/feta_object_ranker.py
+++ b/csrank/objectranking/feta_object_ranker.py
@@ -23,7 +23,7 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="selu",
-        optimizer=SGD(),
+        optimizer=SGD,
         metrics=None,
         batch_size=256,
         random_state=None,
@@ -67,8 +67,10 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
                 Initialization function for the weights of each hidden layer
             activation : string or function
                 Activation function to use in the hidden units
-            optimizer : string or function
-                Stochastic gradient optimizer
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             metrics : list
                 List of evaluation metrics (can be non-differentiable)
             batch_size : int

--- a/csrank/objectranking/rank_net.py
+++ b/csrank/objectranking/rank_net.py
@@ -20,7 +20,7 @@ class RankNet(RankNetCore, ObjectRanker):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(),
+        optimizer=SGD,
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
@@ -54,8 +54,10 @@ class RankNet(RankNetCore, ObjectRanker):
                 Initialization function for the weights of each hidden layer
             activation : function or string
                 Type of activation function to use in each hidden layer
-            optimizer : function or string
-                Optimizer to use during stochastic gradient descent
+            optimizer: Class
+                Uninitialized optimizer class following the keras optimizer interface.
+            optimizer__{kwarg}
+                Arguments to be passed to the optimizer on initialization, such as optimizer__lr.
             metrics : list
                 List of metrics to evaluate during training (can be non-differentiable)
             batch_size : int

--- a/csrank/tests/test_choice_functions.py
+++ b/csrank/tests/test_choice_functions.py
@@ -27,7 +27,12 @@ choice_metrics = {
     "Informedness": instance_informedness,
     "AucScore": auc_score,
 }
-optimizer = SGD(lr=1e-3, momentum=0.9, nesterov=True)
+optimizer_common_args = {
+    "optimizer": SGD,
+    "optimizer__lr": 1e-3,
+    "optimizer__momentum": 0.9,
+    "optimizer__nesterov": True,
+}
 
 
 def get_vals(values):
@@ -37,7 +42,7 @@ def get_vals(values):
 choice_functions = {
     FETA_CHOICE: (
         FETAChoiceFunction,
-        {"add_zeroth_order_model": True, "optimizer": optimizer},
+        {"add_zeroth_order_model": True, **optimizer_common_args},
         get_vals([0.946, 0.9684, 0.9998]),
     ),
     FATE_CHOICE: (
@@ -47,7 +52,7 @@ choice_functions = {
             "n_hidden_set_layers": 1,
             "n_hidden_joint_units": 5,
             "n_hidden_set_units": 5,
-            "optimizer": optimizer,
+            **optimizer_common_args,
         },
         get_vals([0.8185, 0.6070, 0.9924]),
     ),
@@ -63,12 +68,12 @@ choice_functions = {
     ),
     RANKNET_CHOICE: (
         RankNetChoiceFunction,
-        {"optimizer": optimizer},
+        optimizer_common_args.copy(),
         get_vals([0.9522, 0.9866, 1.0]),
     ),
     CMPNET_CHOICE: (
         CmpNetChoiceFunction,
-        {"optimizer": optimizer},
+        optimizer_common_args.copy(),
         get_vals([0.8554, 0.8649, 0.966]),
     ),
     GLM_CHOICE: (GeneralizedLinearModel, {}, get_vals([0.9567, 0.9955, 1.0])),

--- a/csrank/tests/test_discrete_choice.py
+++ b/csrank/tests/test_discrete_choice.py
@@ -30,7 +30,12 @@ metrics = {
     "CategoricalAccuracy": categorical_accuracy_np,
     "CategoricalTopK2": topk_categorical_accuracy_np(k=2),
 }
-optimizer = SGD(lr=1e-3, momentum=0.9, nesterov=True)
+optimizer_common_args = {
+    "optimizer": SGD,
+    "optimizer__lr": 1e-3,
+    "optimizer__momentum": 0.9,
+    "optimizer__nesterov": True,
+}
 
 
 def get_vals(values=[1.0, 1.0]):
@@ -40,17 +45,17 @@ def get_vals(values=[1.0, 1.0]):
 discrete_choice_functions = {
     FETA_DC: (
         FETADiscreteChoiceFunction,
-        {"n_hidden": 1, "optimizer": optimizer},
+        {"n_hidden": 1, **optimizer_common_args},
         get_vals([0.978, 1.0]),
     ),
     RANKNET_DC: (
         RankNetDiscreteChoiceFunction,
-        {"optimizer": optimizer},
+        optimizer_common_args.copy(),
         get_vals([0.97, 0.996]),
     ),
     CMPNET_DC: (
         CmpNetDiscreteChoiceFunction,
-        {"optimizer": optimizer},
+        optimizer_common_args.copy(),
         get_vals([0.994, 1.0]),
     ),
     FATE_DC: (
@@ -60,7 +65,7 @@ discrete_choice_functions = {
             "n_hidden_set_layers": 1,
             "n_hidden_joint_units": 5,
             "n_hidden_set_units": 5,
-            "optimizer": optimizer,
+            **optimizer_common_args,
         },
         get_vals([0.95, 0.998]),
     ),

--- a/csrank/tests/test_fate.py
+++ b/csrank/tests/test_fate.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from csrank import FATENetworkCore
 from csrank import FATEObjectRanker
-from csrank.tests.test_ranking import optimizer
+from csrank.tests.test_ranking import optimizer_common_args
 
 
 def test_construction_core():
@@ -33,6 +33,7 @@ def test_construction_core():
             pass
 
     grc = MockClass()
+    grc._initialize_optimizer()
     grc._construct_layers(
         activation=grc.activation,
         kernel_initializer=grc.kernel_initializer,
@@ -42,7 +43,7 @@ def test_construction_core():
     scores = grc.join_input_layers(input_layer, None, n_layers=0, n_objects=n_objects)
 
     model = Model(inputs=input_layer, outputs=scores)
-    model.compile(loss="mse", optimizer=grc.optimizer)
+    model.compile(loss="mse", optimizer=grc.optimizer_)
     X = np.random.randn(100, n_objects, n_features)
     y = X.sum(axis=2)
     model.fit(x=X, y=y, verbose=0)
@@ -59,8 +60,8 @@ def test_construction_core():
     assert grc.batch_size == params["batch_size"]
     rtol = 1e-2
     atol = 1e-4
-    key = "learning_rate" if "learning_rate" in grc.optimizer.get_config() else "lr"
-    learning_rate = grc.optimizer.get_config().get(key, 0.0)
+    key = "learning_rate" if "learning_rate" in grc.optimizer_.get_config() else "lr"
+    learning_rate = grc.optimizer_.get_config().get(key, 0.0)
     assert np.isclose(
         learning_rate, params["learning_rate"], rtol=rtol, atol=atol, equal_nan=False
     )
@@ -88,7 +89,7 @@ def test_fate_object_ranker_fixed_generator():
         n_hidden_joint_units=5,
         n_hidden_set_units=5,
         kernel_regularizer=l2(1e-4),
-        optimizer=optimizer,
+        **optimizer_common_args,
     )
     fate.fit_generator(
         generator=trivial_ranking_problem_generator(),

--- a/docs/notebooks/FATE-Net-DC.ipynb
+++ b/docs/notebooks/FATE-Net-DC.ipynb
@@ -140,7 +140,10 @@
     "from csrank.losses import smooth_rank_loss\n",
     "fate = FATEObjectRanker(\n",
     "    loss_function=smooth_rank_loss,\n",
-    "    optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9))"
+    "    optimizer=SGD,\n",
+    "    optimizer__lr=1e-4,\n",
+    "    optimizer__nesterov=True,\n",
+    "    optimizer__momentum=0.9)"
    ]
   },
   {

--- a/docs/notebooks/FATE-Net-Ranking.ipynb
+++ b/docs/notebooks/FATE-Net-Ranking.ipynb
@@ -132,7 +132,10 @@
     "from csrank.losses import smooth_rank_loss\n",
     "fate = FATEObjectRanker(\n",
     "    loss_function=smooth_rank_loss,\n",
-    "    optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9))"
+    "    optimizer=SGD,\n",
+    "    optimizer__lr=1e-4,\n",
+    "    optimizer__nesterov=True,\n",
+    "    optimizer__momentum=0.9)"
    ]
   },
   {

--- a/docs/notebooks/Rank-Net-Choice.ipynb
+++ b/docs/notebooks/Rank-Net-Choice.ipynb
@@ -124,7 +124,7 @@
    "outputs": [],
    "source": [
     "ranknet = RankNetChoiceFunction(\n",
-    "    optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9))"
+    "    optimizer=SGD, optimizer__lr=1e-4, optimizer__nesterov=True, optimizer__momentum=0.9)"
    ]
   },
   {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ psycopg2-binary>=2.7
 docopt>=0.6.0
 joblib>=0.9.4
 tqdm>=4.11.2
-keras>=2.3
+keras>=2.3,<2.4
 pymc3>=3.8
 theano>=1.0
 # Pick either CPU or GPU version of tensorflow:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
             "docopt>=0.6.0",
             "joblib>=0.9.4",
             "tqdm>=4.11.2",
-            "keras>=2.3",
+            "keras>=2.3,<2.4",  # 2.4 delegates to tf, needs tf2
             # Pick either CPU or GPU version of tensorflow:
             "tensorflow>=1.5,<2.0",
             # tensorflow-gpu>=1.0.1"


### PR DESCRIPTION
## Description

An initialized optimizer is a tensorflow object, which (at least in
graph mode in tf1) is not deepcopy-able. Even if we were able to
deeocopy it, we probably wouldn't want to since it contains state.
Scikit-learn needs to be able to deepcopy an estimators arguments so
that it can create copies and derivatives of it.

Instead we require the uninitialized optimizer and its parameters to be
passed to our learners separately. The learner can then initialize the
optimizer as needed.


~I have only done this for `CmpNet` so far. We'd have to do it for all estimators that take an optimizer (i.e. pretty much all of them). Before I do that, I would like some feedback on the general approach. I went with a function with out arguments since that retains the most flexibility. It may be a bit weird to users that want to override the optimizer though. An alternative would be to pass the name of a keras optimizer and a configuration dict. That would be less "weird", but also less flexible since users could no longer write their own custom estimators. @kiudee @prithagupta any thoughts?~

## Motivation and Context

Continuation of #116.

## How Has This Been Tested?

Ran the test suite and the pre-commit hooks.

## Does this close/impact existing issues?

#94, #116 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
