### PR TITLE
 Always raise ValueError on unknown variants

### DIFF
--- a/csrank/callbacks.py
+++ b/csrank/callbacks.py
@@ -1,6 +1,5 @@
 import logging
 import math
-import warnings
 
 from keras import backend as K
 from keras.callbacks import Callback
@@ -61,12 +60,11 @@ class EarlyStoppingWithWeights(Callback, Tunable):
         self.restore_best_weights = restore_best_weights
         self.best_weights = None
 
-        if mode not in ["auto", "min", "max"]:
-            warnings.warn(
-                "EarlyStopping mode %s is unknown, " "fallback to auto mode." % mode,
-                RuntimeWarning,
+        known_modes = {"auto", "min", "max"}
+        if mode not in known_modes:
+            raise ValueError(
+                f"EarlyStopping mode {mode} is unknown, must be one of {known_modes}"
             )
-            mode = "auto"
 
         if mode == "min":
             self.monitor_op = np.less

--- a/csrank/callbacks.py
+++ b/csrank/callbacks.py
@@ -20,7 +20,7 @@ class EarlyStoppingWithWeights(Callback, Tunable):
         mode="auto",
         baseline=None,
         restore_best_weights=False,
-        **kwargs
+        **kwargs,
     ):
         """Stop training when a monitored quantity has stopped improving.
 

--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -23,7 +23,7 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create an instance of the :class:`CmpNetCore` architecture for learning a choice function.
@@ -88,7 +88,7 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(CmpNetChoiceFunction.__name__)
         self.logger.info("Initializing network")
@@ -121,7 +121,7 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
         tune_size=0.1,
         thin_thresholds=1,
         verbose=0,
-        **kwd
+        **kwd,
     ):
         """
             Fit a CmptNet model for learning a choice fucntion on the provided set of queries X and preferences Y of
@@ -171,7 +171,7 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
                     callbacks,
                     validation_split,
                     verbose,
-                    **kwd
+                    **kwd,
                 )
             finally:
                 self.logger.info(
@@ -203,7 +203,7 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden=n_hidden,
@@ -211,5 +211,5 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -25,7 +25,7 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
         batch_size=256,
         metrics=None,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATE-network architecture for leaning discrete choice function. The first-aggregate-then-evaluate
@@ -89,7 +89,7 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
             optimizer=optimizer,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FATEChoiceFunction.__name__)
         self.threshold = 0.5
@@ -146,7 +146,7 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
         refit=False,
         tune_size=0.1,
         thin_thresholds=1,
-        **kwargs
+        **kwargs,
     ):
         """
             Fit a generic FATE-network model for learning a choice function on a provided set of queries.
@@ -233,7 +233,7 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden_set_units=n_hidden_set_units,
@@ -243,5 +243,5 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/choicefunction/fatelinear_choice.py
+++ b/csrank/choicefunction/fatelinear_choice.py
@@ -15,7 +15,7 @@ class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
         learning_rate=1e-3,
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATELinear-network architecture for leaning discrete choice function. The first-aggregate-then-evaluate
@@ -56,7 +56,7 @@ class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
             batch_size=batch_size,
             loss_function=loss_function,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FATELinearChoiceFunction.__name__)
 
@@ -70,7 +70,7 @@ class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
         tune_size=0.1,
         thin_thresholds=1,
         verbose=0,
-        **kwd
+        **kwd,
     ):
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
@@ -84,7 +84,7 @@ class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
                     callbacks,
                     validation_split,
                     verbose,
-                    **kwd
+                    **kwd,
                 )
             finally:
                 self.logger.info(
@@ -116,7 +116,7 @@ class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
         batch_size=128,
         epochs_drop=300,
         drop=0.1,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden_set_units=n_hidden_set_units,
@@ -124,5 +124,5 @@ class FATELinearChoiceFunction(FATELinearCore, ChoiceFunctions):
             batch_size=batch_size,
             epochs_drop=epochs_drop,
             drop=drop,
-            **point
+            **point,
         )

--- a/csrank/choicefunction/feta_choice.py
+++ b/csrank/choicefunction/feta_choice.py
@@ -38,7 +38,7 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FETA-network architecture for learning choice functions.
@@ -105,7 +105,7 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.threshold = 0.5
         self.logger = logging.getLogger(FETAChoiceFunction.__name__)
@@ -237,7 +237,7 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
         tune_size=0.1,
         thin_thresholds=1,
         verbose=0,
-        **kwd
+        **kwd,
     ):
         """
             Fit a FETA-Network for learning a choice function on the provided set of queries X and preferences Y of
@@ -276,7 +276,7 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
                     callbacks,
                     validation_split,
                     verbose,
-                    **kwd
+                    **kwd,
                 )
             finally:
                 self.logger.info(
@@ -372,7 +372,7 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden=n_hidden,
@@ -380,5 +380,5 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/choicefunction/fetalinear_choice.py
+++ b/csrank/choicefunction/fetalinear_choice.py
@@ -14,7 +14,7 @@ class FETALinearChoiceFunction(FETALinearCore, ChoiceFunctions):
         learning_rate=5e-3,
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATELinear-network architecture for leaning discrete choice function. The first-aggregate-then-evaluate
@@ -54,7 +54,7 @@ class FETALinearChoiceFunction(FETALinearCore, ChoiceFunctions):
             batch_size=batch_size,
             loss_function=loss_function,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FETALinearChoiceFunction.__name__)
 
@@ -68,7 +68,7 @@ class FETALinearChoiceFunction(FETALinearCore, ChoiceFunctions):
         tune_size=0.1,
         thin_thresholds=1,
         verbose=0,
-        **kwd
+        **kwd,
     ):
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
@@ -82,7 +82,7 @@ class FETALinearChoiceFunction(FETALinearCore, ChoiceFunctions):
                     callbacks,
                     validation_split,
                     verbose,
-                    **kwd
+                    **kwd,
                 )
             finally:
                 self.logger.info(
@@ -115,5 +115,5 @@ class FETALinearChoiceFunction(FETALinearCore, ChoiceFunctions):
             batch_size=batch_size,
             epochs_drop=epochs_drop,
             drop=drop,
-            **point
+            **point,
         )

--- a/csrank/choicefunction/generalized_linear_model.py
+++ b/csrank/choicefunction/generalized_linear_model.py
@@ -175,7 +175,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
             "callbacks": [CheckParametersConvergence()],
         },
         verbose=0,
-        **kwargs
+        **kwargs,
     ):
         """
             Fit a generalized logit model on the provided set of queries X and choices Y of those objects. The
@@ -251,7 +251,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
                     ],
                     "draws": 500,
                 },
-                **kwargs
+                **kwargs,
             )
             self.threshold = 0.5
 
@@ -267,7 +267,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
             "method": "advi",
             "callbacks": [CheckParametersConvergence()],
         },
-        **kwargs
+        **kwargs,
     ):
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         self.construct_model(X, Y)

--- a/csrank/choicefunction/pairwise_choice.py
+++ b/csrank/choicefunction/pairwise_choice.py
@@ -15,7 +15,7 @@ class PairwiseSVMChoiceFunction(PairwiseSVM, ChoiceFunctions):
         normalize=True,
         fit_intercept=True,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create an instance of the :class:`PairwiseSVM` model for learning a choice function.
@@ -56,7 +56,7 @@ class PairwiseSVMChoiceFunction(PairwiseSVM, ChoiceFunctions):
             normalize=normalize,
             fit_intercept=fit_intercept,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(PairwiseSVMChoiceFunction.__name__)
         self.logger.info("Initializing network")

--- a/csrank/choicefunction/ranknet_choice.py
+++ b/csrank/choicefunction/ranknet_choice.py
@@ -23,7 +23,7 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create an instance of the :class:`RankNetCore` architecture for learning a object ranking function.
@@ -82,7 +82,7 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(RankNetChoiceFunction.__name__)
         self.logger.info("Initializing network")
@@ -116,7 +116,7 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
         tune_size=0.1,
         thin_thresholds=1,
         verbose=0,
-        **kwd
+        **kwd,
     ):
         """
             Fit RankNet model for learning choice function on a provided set of queries. The provided queries can be of
@@ -163,7 +163,7 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
                     callbacks,
                     validation_split,
                     verbose,
-                    **kwd
+                    **kwd,
                 )
             finally:
                 self.logger.info(
@@ -199,7 +199,7 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden=n_hidden,
@@ -207,5 +207,5 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/core/cmpnet_core.py
+++ b/csrank/core/cmpnet_core.py
@@ -33,7 +33,7 @@ class CmpNetCore(Learner):
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         self.logger = logging.getLogger("CmpNet")
         self.batch_normalization = batch_normalization
@@ -158,7 +158,7 @@ class CmpNetCore(Learner):
             kernel_regularizer=self.kernel_regularizer,
             kernel_initializer=self.kernel_initializer,
             activation=self.activation,
-            **self.kwargs
+            **self.kwargs,
         )
         self.model = self.construct_model()
 
@@ -171,7 +171,7 @@ class CmpNetCore(Learner):
             callbacks=callbacks,
             validation_split=validation_split,
             verbose=verbose,
-            **kwd
+            **kwd,
         )
         self.logger.debug("Fitting Complete")
 
@@ -217,7 +217,7 @@ class CmpNetCore(Learner):
                 kernel_regularizer=self.kernel_regularizer,
                 kernel_initializer=self.kernel_initializer,
                 activation=self.activation,
-                **self.kwargs
+                **self.kwargs,
             )
             self.model = self.construct_model()
             self.model.load_weights(self.hash_file)
@@ -231,7 +231,7 @@ class CmpNetCore(Learner):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         """
             Set tunable parameters of the CmpNet network to the values provided.
@@ -261,7 +261,7 @@ class CmpNetCore(Learner):
             kernel_regularizer=self.kernel_regularizer,
             kernel_initializer=self.kernel_initializer,
             activation=self.activation,
-            **self.kwargs
+            **self.kwargs,
         )
         if len(point) > 0:
             self.logger.warning(

--- a/csrank/core/fate_linear.py
+++ b/csrank/core/fate_linear.py
@@ -21,7 +21,7 @@ class FATELinearCore(Learner):
         epochs_drop=300,
         drop=0.1,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         self.n_hidden_set_units = n_hidden_set_units
         self.learning_rate = learning_rate
@@ -155,7 +155,7 @@ class FATELinearCore(Learner):
         batch_size=128,
         epochs_drop=300,
         drop=0.1,
-        **point
+        **point,
     ):
         """
             Set tunable parameters of the FETA-network to the values provided.

--- a/csrank/core/fate_network.py
+++ b/csrank/core/fate_network.py
@@ -32,7 +32,7 @@ class FATENetworkCore(Learner):
         optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATE-network architecture.
@@ -82,7 +82,7 @@ class FATENetworkCore(Learner):
             activation=self.activation,
             kernel_initializer=self.kernel_initializer,
             kernel_regularizer=self.kernel_regularizer,
-            **self.kwargs
+            **self.kwargs,
         )
 
     def _construct_layers(self, **kwargs):
@@ -160,7 +160,7 @@ class FATENetworkCore(Learner):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         self.n_hidden_joint_layers = n_hidden_joint_layers
         self.n_hidden_joint_units = n_hidden_joint_units
@@ -174,7 +174,7 @@ class FATENetworkCore(Learner):
             activation=self.activation,
             kernel_initializer=self.kernel_initializer,
             kernel_regularizer=self.kernel_regularizer,
-            **self.kwargs
+            **self.kwargs,
         )
 
         if len(point) > 0:
@@ -307,7 +307,7 @@ class FATENetwork(FATENetworkCore):
         min_bucket_size=500,
         refit=False,
         optimizer=None,
-        **kwargs
+        **kwargs,
     ):
         if optimizer is not None:
             self.optimizer = optimizer
@@ -361,7 +361,7 @@ class FATENetwork(FATENetworkCore):
                         batch_size=self.batch_size,
                         validation_split=validation_split,
                         verbose=verbose,
-                        **kwargs
+                        **kwargs,
                     )
                     w_after = np.array(self.get_weights())
                     self.set_weights(
@@ -390,7 +390,7 @@ class FATENetwork(FATENetworkCore):
                     validation_split=validation_split,
                     batch_size=self.batch_size,
                     verbose=verbose,
-                    **kwargs
+                    **kwargs,
                 )
             else:
                 self.model.fit_generator(
@@ -398,7 +398,7 @@ class FATENetwork(FATENetworkCore):
                     callbacks=callbacks,
                     epochs=epochs,
                     verbose=verbose,
-                    **kwargs
+                    **kwargs,
                 )
             self.logger.info("Fitting complete")
 
@@ -452,7 +452,7 @@ class FATENetwork(FATENetworkCore):
         global_momentum=0.9,
         min_bucket_size=500,
         refit=False,
-        **kwargs
+        **kwargs,
     ):
         """
             Fit a generic preference learning FATE-network model on a provided set of queries.
@@ -509,7 +509,7 @@ class FATENetwork(FATENetworkCore):
             global_momentum=global_momentum,
             min_bucket_size=min_bucket_size,
             refit=refit,
-            **kwargs
+            **kwargs,
         )
 
     def fit_generator(
@@ -524,7 +524,7 @@ class FATENetwork(FATENetworkCore):
         global_momentum=0.9,
         min_bucket_size=500,
         refit=False,
-        **kwargs
+        **kwargs,
     ):
         """
             Fit a generic object ranking FATE-network on a set of queries provided by
@@ -585,7 +585,7 @@ class FATENetwork(FATENetworkCore):
             global_momentum=global_momentum,
             min_bucket_size=min_bucket_size,
             refit=refit,
-            **kwargs
+            **kwargs,
         )
 
     def _get_context_representation(self, X, kwargs):
@@ -669,13 +669,13 @@ class FATENetwork(FATENetworkCore):
                 activation=self.activation,
                 kernel_initializer=self.kernel_initializer,
                 kernel_regularizer=self.kernel_regularizer,
-                **self.kwargs
+                **self.kwargs,
             )
             self._create_set_layers(
                 activation=self.activation,
                 kernel_initializer=self.kernel_initializer,
                 kernel_regularizer=self.kernel_regularizer,
-                **self.kwargs
+                **self.kwargs,
             )
             self.model = self.construct_model(self.n_object_features_fit_, n_objects)
             self.model.load_weights(self.hash_file)
@@ -691,7 +691,7 @@ class FATENetwork(FATENetworkCore):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         """
             Set tunable parameters of the FATE-network to the values provided.
@@ -722,7 +722,7 @@ class FATENetwork(FATENetworkCore):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )
 
         self.n_hidden_set_units = n_hidden_set_units
@@ -732,7 +732,7 @@ class FATENetwork(FATENetworkCore):
             activation=self.activation,
             kernel_initializer=self.kernel_initializer,
             kernel_regularizer=self.kernel_regularizer,
-            **self.kwargs
+            **self.kwargs,
         )
         if hasattr(self, "model"):
             self.model = None

--- a/csrank/core/feta_linear.py
+++ b/csrank/core/feta_linear.py
@@ -21,7 +21,7 @@ class FETALinearCore(Learner):
         epochs_drop=50,
         drop=0.01,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         self.learning_rate = learning_rate
         self.batch_size = batch_size

--- a/csrank/core/feta_network.py
+++ b/csrank/core/feta_network.py
@@ -40,7 +40,7 @@ class FETANetwork(Learner):
         metrics=None,
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         self.logger = logging.getLogger(FETANetwork.__name__)
         self.random_state = random_state
@@ -286,7 +286,7 @@ class FETANetwork(Learner):
             kernel_regularizer=self.kernel_regularizer,
             kernel_initializer=self.kernel_initializer,
             activation=self.activation,
-            **self.kwargs
+            **self.kwargs,
         )
 
         self.logger.debug("Enter fit function...")
@@ -304,7 +304,7 @@ class FETANetwork(Learner):
             callbacks=callbacks,
             validation_split=validation_split,
             verbose=verbose,
-            **kwd
+            **kwd,
         )
         if self.hash_file is not None:
             self.model.save_weights(self.hash_file)
@@ -345,7 +345,7 @@ class FETANetwork(Learner):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         """
             Set tunable parameters of the FETA-network to the values provided.
@@ -377,7 +377,7 @@ class FETANetwork(Learner):
             kernel_regularizer=self.kernel_regularizer,
             kernel_initializer=self.kernel_initializer,
             activation=self.activation,
-            **self.kwargs
+            **self.kwargs,
         )
         if len(point) > 0:
             self.logger.warning(
@@ -407,7 +407,7 @@ class FETANetwork(Learner):
                 kernel_regularizer=self.kernel_regularizer,
                 kernel_initializer=self.kernel_initializer,
                 activation=self.activation,
-                **self.kwargs
+                **self.kwargs,
             )
             self.model = self.construct_model()
             self.model.load_weights(self.hash_file)

--- a/csrank/core/pairwise_svm.py
+++ b/csrank/core/pairwise_svm.py
@@ -18,7 +18,7 @@ class PairwiseSVM(Learner):
         normalize=True,
         fit_intercept=True,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """ Create an instance of the PairwiseSVM model for any preference learner.
 

--- a/csrank/core/ranknet_core.py
+++ b/csrank/core/ranknet_core.py
@@ -32,7 +32,7 @@ class RankNetCore(Learner):
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         self.logger = logging.getLogger(RankNetCore.__name__)
         self.batch_normalization = batch_normalization
@@ -151,7 +151,7 @@ class RankNetCore(Learner):
             kernel_regularizer=self.kernel_regularizer,
             kernel_initializer=self.kernel_initializer,
             activation=self.activation,
-            **self.kwargs
+            **self.kwargs,
         )
 
         # Model with input as two objects and output as probability of x1>x2
@@ -166,7 +166,7 @@ class RankNetCore(Learner):
             callbacks=callbacks,
             validation_split=validation_split,
             verbose=verbose,
-            **kwd
+            **kwd,
         )
 
         self.logger.debug("Fitting Complete")
@@ -222,7 +222,7 @@ class RankNetCore(Learner):
                 kernel_regularizer=self.kernel_regularizer,
                 kernel_initializer=self.kernel_initializer,
                 activation=self.activation,
-                **self.kwargs
+                **self.kwargs,
             )
             self.model = self.construct_model()
             self.model.load_weights(self.hash_file)
@@ -236,7 +236,7 @@ class RankNetCore(Learner):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         """
             Set tunable parameters of the RankNet network to the values provided.
@@ -267,7 +267,7 @@ class RankNetCore(Learner):
             kernel_regularizer=self.kernel_regularizer,
             kernel_initializer=self.kernel_initializer,
             activation=self.activation,
-            **self.kwargs
+            **self.kwargs,
         )
         if len(point) > 0:
             self.logger.warning(

--- a/csrank/dataset_reader/choicefunctions/choice_data_generator.py
+++ b/csrank/dataset_reader/choicefunctions/choice_data_generator.py
@@ -15,7 +15,9 @@ class ChoiceDatasetGenerator(SyntheticDatasetGenerator):
             "pareto": self.make_globular_pareto_choices,
         }
         if dataset_type not in dataset_function_options.keys():
-            dataset_type = "pareto"
+            raise ValueError(
+                f"dataset_type must be one of {set(dataset_function_options.keys())}"
+            )
         self.dataset_function = dataset_function_options[dataset_type]
 
     def get_single_train_test_split(self):

--- a/csrank/dataset_reader/choicefunctions/choice_data_generator.py
+++ b/csrank/dataset_reader/choicefunctions/choice_data_generator.py
@@ -34,7 +34,7 @@ class ChoiceDatasetGenerator(SyntheticDatasetGenerator):
         seed=42,
         cluster_spread=1.0,
         cluster_size=10,
-        **kwargs
+        **kwargs,
     ):
         def pareto_front(X, signs=None):
             n_points, n_attributes = X.shape
@@ -96,7 +96,7 @@ class ChoiceDatasetGenerator(SyntheticDatasetGenerator):
         n_rep_units=5,
         threshold=0.0,
         seed=42,
-        **kwargs
+        **kwargs,
     ):
         rand = check_random_state(seed)
         ranw = check_random_state(rand.randint(2 ** 32, dtype="uint32"))

--- a/csrank/dataset_reader/choicefunctions/choice_data_generator.py
+++ b/csrank/dataset_reader/choicefunctions/choice_data_generator.py
@@ -14,7 +14,7 @@ class ChoiceDatasetGenerator(SyntheticDatasetGenerator):
             "linear": self.make_latent_linear_choices,
             "pareto": self.make_globular_pareto_choices,
         }
-        if dataset_type not in dataset_function_options.keys():
+        if dataset_type not in dataset_function_options:
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_function_options.keys())}"
             )

--- a/csrank/dataset_reader/choicefunctions/mnist_choice_dataset_reader.py
+++ b/csrank/dataset_reader/choicefunctions/mnist_choice_dataset_reader.py
@@ -11,7 +11,7 @@ class MNISTChoiceDatasetReader(MNISTDatasetReader):
             "largest": self.create_dataset_largest,
             "mode": self.create_dataset_mode,
         }
-        if dataset_type not in dataset_func_dict.keys():
+        if dataset_type not in dataset_func_dict:
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_func_dict.keys())}"
             )

--- a/csrank/dataset_reader/choicefunctions/mnist_choice_dataset_reader.py
+++ b/csrank/dataset_reader/choicefunctions/mnist_choice_dataset_reader.py
@@ -12,7 +12,9 @@ class MNISTChoiceDatasetReader(MNISTDatasetReader):
             "mode": self.create_dataset_mode,
         }
         if dataset_type not in dataset_func_dict.keys():
-            dataset_type = "unique"
+            raise ValueError(
+                f"dataset_type must be one of {set(dataset_func_dict.keys())}"
+            )
         self.dataset_function = dataset_func_dict[dataset_type]
         super(MNISTChoiceDatasetReader, self).__init__(
             learning_problem=CHOICE_FUNCTION, **kwargs

--- a/csrank/dataset_reader/discretechoice/discrete_choice_data_generator.py
+++ b/csrank/dataset_reader/discretechoice/discrete_choice_data_generator.py
@@ -32,7 +32,7 @@ class DiscreteChoiceDatasetGenerator(SyntheticDatasetGenerator):
             "gp_transitive": self.make_gp_transitive,
             "gp_non_transitive": self.make_gp_non_transitive,
         }
-        if dataset_type not in dataset_function_options.keys():
+        if dataset_type not in dataset_function_options:
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_function_options.keys())}"
             )

--- a/csrank/dataset_reader/discretechoice/discrete_choice_data_generator.py
+++ b/csrank/dataset_reader/discretechoice/discrete_choice_data_generator.py
@@ -45,7 +45,7 @@ class DiscreteChoiceDatasetGenerator(SyntheticDatasetGenerator):
         n_features=100,
         n_informative=10,
         seed=42,
-        **kwd
+        **kwd,
     ):
         random_state = check_random_state(seed=seed)
         X, y, coeff = make_regression(
@@ -101,7 +101,7 @@ class DiscreteChoiceDatasetGenerator(SyntheticDatasetGenerator):
         n_features=5,
         seed=42,
         cluster_spread=1.0,
-        **kwd
+        **kwd,
     ):
         def sample_unit_ball(n_f=2, rng=None, radius=1.0):
             rng = check_random_state(rng)
@@ -133,7 +133,7 @@ class DiscreteChoiceDatasetGenerator(SyntheticDatasetGenerator):
         n_features=100,
         kernel_params=None,
         seed=42,
-        **kwd
+        **kwd,
     ):
         """Creates a nonlinear object ranking problem by sampling from a
         Gaussian process as the latent utility function.
@@ -164,7 +164,7 @@ class DiscreteChoiceDatasetGenerator(SyntheticDatasetGenerator):
         center_box=(-10.0, 10.0),
         cluster_std=2.0,
         seed=42,
-        **kwd
+        **kwd,
     ):
         n_samples = n_instances * n_objects
         random_state = check_random_state(seed=seed)

--- a/csrank/dataset_reader/discretechoice/discrete_choice_data_generator.py
+++ b/csrank/dataset_reader/discretechoice/discrete_choice_data_generator.py
@@ -33,7 +33,9 @@ class DiscreteChoiceDatasetGenerator(SyntheticDatasetGenerator):
             "gp_non_transitive": self.make_gp_non_transitive,
         }
         if dataset_type not in dataset_function_options.keys():
-            dataset_type = "medoid"
+            raise ValueError(
+                f"dataset_type must be one of {set(dataset_function_options.keys())}"
+            )
         self.logger.info("dataset type {}".format(dataset_type))
         self.dataset_function = dataset_function_options[dataset_type]
 

--- a/csrank/dataset_reader/discretechoice/mnist_discrete_choice_dataset_reader.py
+++ b/csrank/dataset_reader/discretechoice/mnist_discrete_choice_dataset_reader.py
@@ -15,7 +15,9 @@ class MNISTDiscreteChoiceDatasetReader(MNISTDatasetReader):
             "unique_max_occurring": self.create_dataset_mode_least_angle,
         }
         if dataset_type not in dataset_func_dict.keys():
-            dataset_type = "median"
+            raise ValueError(
+                f"dataset_type must be one of {set(dataset_func_dict.keys())}"
+            )
         self.dataset_function = dataset_func_dict[dataset_type]
         super(MNISTDiscreteChoiceDatasetReader, self).__init__(
             learning_problem=DISCRETE_CHOICE, **kwargs

--- a/csrank/dataset_reader/discretechoice/mnist_discrete_choice_dataset_reader.py
+++ b/csrank/dataset_reader/discretechoice/mnist_discrete_choice_dataset_reader.py
@@ -14,7 +14,7 @@ class MNISTDiscreteChoiceDatasetReader(MNISTDatasetReader):
             "median": self.create_dataset_median,
             "unique_max_occurring": self.create_dataset_mode_least_angle,
         }
-        if dataset_type not in dataset_func_dict.keys():
+        if dataset_type not in dataset_func_dict:
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_func_dict.keys())}"
             )

--- a/csrank/dataset_reader/discretechoice/tag_genome_discrete_choice_dataset_reader.py
+++ b/csrank/dataset_reader/discretechoice/tag_genome_discrete_choice_dataset_reader.py
@@ -26,7 +26,9 @@ class TagGenomeDiscreteChoiceDatasetReader(TagGenomeDatasetReader):
             ),
         }
         if dataset_type not in dataset_func_dict.keys():
-            dataset_type = "nearest_neighbour"
+            raise ValueError(
+                f"dataset_type must be one of {set(dataset_func_dict.keys())}"
+            )
         self.logger.info("Dataset type: {}".format(dataset_type))
         self.dataset_function = dataset_func_dict[dataset_type]
 

--- a/csrank/dataset_reader/discretechoice/tag_genome_discrete_choice_dataset_reader.py
+++ b/csrank/dataset_reader/discretechoice/tag_genome_discrete_choice_dataset_reader.py
@@ -25,7 +25,7 @@ class TagGenomeDiscreteChoiceDatasetReader(TagGenomeDatasetReader):
                 direction=-1
             ),
         }
-        if dataset_type not in dataset_func_dict.keys():
+        if dataset_type not in dataset_func_dict:
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_func_dict.keys())}"
             )

--- a/csrank/dataset_reader/labelranking/intelligent_system_group_dataset_reader.py
+++ b/csrank/dataset_reader/labelranking/intelligent_system_group_dataset_reader.py
@@ -23,7 +23,7 @@ class IntelligentSystemGroupDatasetReader(DatasetReader):
         super(IntelligentSystemGroupDatasetReader, self).__init__(
             learning_problem=LABEL_RANKING,
             dataset_folder="intelligent_system_data",
-            **kwargs
+            **kwargs,
         )
 
         self.logger = logging.getLogger(IntelligentSystemGroupDatasetReader.__name__)

--- a/csrank/dataset_reader/letor_listwise_dataset_reader.py
+++ b/csrank/dataset_reader/letor_listwise_dataset_reader.py
@@ -31,10 +31,9 @@ class LetorListwiseDatasetReader(DatasetReader, metaclass=ABCMeta):
         self.DATASET_FOLDER_2008 = "MQ{}-list".format(year)
         self.logger = logging.getLogger(LetorListwiseDatasetReader.__name__)
 
-        if year not in [2007, 2008]:
-            self.year = 2007
-        else:
-            self.year = year
+        if year not in {2007, 2008}:
+            raise ValueError("year must be either 2007 or 2008")
+        self.year = year
         self.exclude_qf = exclude_qf
         self.query_feature_indices = [4, 5, 6, 19, 20, 21, 34, 35, 36]
         self.query_document_feature_indices = np.delete(

--- a/csrank/dataset_reader/letor_listwise_dataset_reader.py
+++ b/csrank/dataset_reader/letor_listwise_dataset_reader.py
@@ -192,7 +192,7 @@ class LetorListwiseDatasetReader(DatasetReader, metaclass=ABCMeta):
                     [float(l.split(":")[1]) for l in information[1].split(" ")[1:-1]]
                 )
                 x = np.insert(x, len(x), rel_deg)
-                if qid not in dataset.keys():
+                if qid not in dataset:
                     dataset[qid] = [x]
                 else:
                     dataset[qid].append(x)
@@ -228,7 +228,7 @@ class LetorListwiseDatasetReader(DatasetReader, metaclass=ABCMeta):
             x = X[key]
             y = Y[key]
             s = scores[key]
-            if key in self.X_train.keys():
+            if key in self.X_train:
                 self.X_train[key] = np.append(self.X_train[key], x, axis=0)
                 self.Y_train[key] = np.append(self.Y_train[key], y, axis=0)
                 self.scores_train[key] = np.append(self.scores_train[key], s, axis=0)

--- a/csrank/dataset_reader/letor_ranking_dataset_reader.py
+++ b/csrank/dataset_reader/letor_ranking_dataset_reader.py
@@ -29,9 +29,8 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
         self.logger = logging.getLogger(LetorRankingDatasetReader.__name__)
 
         if year not in [2007, 2008]:
-            self.year = 2007
-        else:
-            self.year = year
+            raise ValueError("year must be either 2007 or 2008")
+        self.year = year
         self.exclude_qf = exclude_qf
         self.query_feature_indices = [4, 5, 6, 19, 20, 21, 34, 35, 36]
         self.query_document_feature_indices = np.delete(

--- a/csrank/dataset_reader/letor_ranking_dataset_reader.py
+++ b/csrank/dataset_reader/letor_ranking_dataset_reader.py
@@ -132,7 +132,7 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
         for key in X.keys():
             x = X[key]
             y = Y[key]
-            if key in self.X_train.keys():
+            if key in self.X_train:
                 self.X_train[key] = np.append(self.X_train[key], x, axis=0)
                 self.Y_train[key] = np.append(self.Y_train[key], y, axis=0)
             else:
@@ -214,7 +214,7 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
                     [float(l.split(":")[1]) for l in information[1].split(" ")[1:-1]]
                 )
                 x = np.insert(x, len(x), rel_deg)
-                if qid not in dataset.keys():
+                if qid not in dataset:
                     dataset[qid] = [x]
                 else:
                     dataset[qid].append(x)

--- a/csrank/dataset_reader/mnist_dataset_reader.py
+++ b/csrank/dataset_reader/mnist_dataset_reader.py
@@ -17,7 +17,7 @@ class MNISTDatasetReader(DatasetReader):
         n_objects=10,
         random_state=None,
         standardize=True,
-        **kwargs
+        **kwargs,
     ):
         super(MNISTDatasetReader, self).__init__(dataset_folder="mnist", **kwargs)
         self.logger = logging.getLogger(MNISTDatasetReader.__name__)

--- a/csrank/dataset_reader/objectranking/depth_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/depth_dataset_reader.py
@@ -23,8 +23,8 @@ class DepthDatasetReader(DatasetReader):
             "basic": ["saxena_basic61x55.dat", "saxena_basicTest61x55.dat"],
             "semantic": ["saxena_semantic61x55.dat", "saxena_semanticTest61x55.dat"],
         }
-        if dataset_type not in options:
-            dataset_type = "deep"
+        if dataset_type not in options.keys():
+            raise ValueError(f"dataset_type must be one of set({options.keys()})")
         train_filename, test_file_name = options[dataset_type]
         self.train_file = os.path.join(self.dirname, train_filename)
         self.test_file = os.path.join(self.dirname, test_file_name)

--- a/csrank/dataset_reader/objectranking/depth_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/depth_dataset_reader.py
@@ -23,7 +23,7 @@ class DepthDatasetReader(DatasetReader):
             "basic": ["saxena_basic61x55.dat", "saxena_basicTest61x55.dat"],
             "semantic": ["saxena_semantic61x55.dat", "saxena_semanticTest61x55.dat"],
         }
-        if dataset_type not in options.keys():
+        if dataset_type not in options:
             raise ValueError(f"dataset_type must be one of set({options.keys()})")
         train_filename, test_file_name = options[dataset_type]
         self.train_file = os.path.join(self.dirname, train_filename)

--- a/csrank/dataset_reader/objectranking/image_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/image_dataset_reader.py
@@ -188,7 +188,7 @@ class ImageDatasetReader(DatasetReader):
             lines = np.array([line.rstrip("\n") for line in open(file)])
             for line in lines:
                 label_keys.append(line.split(" ")[0])
-                if line.split(" ")[0] in label_vectors_dictionary.keys():
+                if line.split(" ")[0] in label_vectors_dictionary:
                     label_vectors_dictionary[line.split(" ")[0]].append(
                         int(line.split(" ")[-1])
                     )

--- a/csrank/dataset_reader/objectranking/image_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/image_dataset_reader.py
@@ -38,7 +38,7 @@ class ImageDatasetReader(DatasetReader):
         n_test_instances=10000,
         n_objects=5,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         super(ImageDatasetReader, self).__init__(
             learning_problem=OBJECT_RANKING, dataset_folder="image_dataset", **kwargs

--- a/csrank/dataset_reader/objectranking/neural_sentence_ordering_reader.py
+++ b/csrank/dataset_reader/objectranking/neural_sentence_ordering_reader.py
@@ -66,7 +66,7 @@ class SentenceOrderingDatasetReader(DatasetReader):
                 else:
                     X = np.concatenate([X, x], axis=0)
                     Y = np.concatenate([Y, y], axis=0)
-        if self.n_objects in self.X_train.keys():
+        if self.n_objects in self.X_train:
             X = np.concatenate([X, np.copy(self.X_train[self.n_objects])], axis=0)
             Y = np.concatenate([Y, np.copy(self.Y_train[self.n_objects])], axis=0)
         self.logger.info(

--- a/csrank/dataset_reader/objectranking/neural_sentence_ordering_reader.py
+++ b/csrank/dataset_reader/objectranking/neural_sentence_ordering_reader.py
@@ -20,7 +20,7 @@ class SentenceOrderingDatasetReader(DatasetReader):
         super(SentenceOrderingDatasetReader, self).__init__(
             learning_problem=OBJECT_RANKING,
             dataset_folder="sentence_ordering",
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(name=SentenceOrderingDatasetReader.__name__)
         dimensions = [25, 50, 100, 200]

--- a/csrank/dataset_reader/objectranking/neural_sentence_ordering_reader.py
+++ b/csrank/dataset_reader/objectranking/neural_sentence_ordering_reader.py
@@ -23,11 +23,11 @@ class SentenceOrderingDatasetReader(DatasetReader):
             **kwargs,
         )
         self.logger = logging.getLogger(name=SentenceOrderingDatasetReader.__name__)
-        dimensions = [25, 50, 100, 200]
+        dimensions = {25, 50, 100, 200}
         d_files = ["test_{}_dim.h5", "train_{}_dim.h5"]
         self.n_objects = n_objects
         if n_dims not in dimensions:
-            n_dims = 25
+            raise ValueError(f"n_dims must be one of {dimensions}")
         self.logger.info("Loading the dataset with {} features".format(n_dims))
         self.train_file = os.path.join(self.dirname, d_files[1]).format(n_dims)
         self.test_file = os.path.join(self.dirname, d_files[0]).format(n_dims)

--- a/csrank/dataset_reader/objectranking/object_ranking_data_generator.py
+++ b/csrank/dataset_reader/objectranking/object_ranking_data_generator.py
@@ -44,7 +44,7 @@ class ObjectRankingDatasetGenerator(SyntheticDatasetGenerator):
         n_features=100,
         n_informative=10,
         seed=42,
-        **kwd
+        **kwd,
     ):
         random_state = check_random_state(seed=seed)
         X, y, coeff = make_regression(
@@ -68,7 +68,7 @@ class ObjectRankingDatasetGenerator(SyntheticDatasetGenerator):
         n_features=100,
         kernel_params=None,
         seed=42,
-        **kwd
+        **kwd,
     ):
         """Creates a nonlinear object ranking problem by sampling from a
         Gaussian process as the latent utility function.
@@ -99,7 +99,7 @@ class ObjectRankingDatasetGenerator(SyntheticDatasetGenerator):
         center_box=(-10.0, 10.0),
         cluster_std=2.0,
         seed=42,
-        **kwd
+        **kwd,
     ):
         n_samples = n_instances * n_objects
         random_state = check_random_state(seed=seed)

--- a/csrank/dataset_reader/objectranking/object_ranking_data_generator.py
+++ b/csrank/dataset_reader/objectranking/object_ranking_data_generator.py
@@ -32,7 +32,7 @@ class ObjectRankingDatasetGenerator(SyntheticDatasetGenerator):
             "gp_non_transitive": self.make_gp_non_transitive,
             "hyper_volume": self.make_hv_dataset,
         }
-        if dataset_type not in dataset_function_options.keys():
+        if dataset_type not in dataset_function_options:
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_function_options.keys())}"
             )

--- a/csrank/dataset_reader/objectranking/object_ranking_data_generator.py
+++ b/csrank/dataset_reader/objectranking/object_ranking_data_generator.py
@@ -33,6 +33,9 @@ class ObjectRankingDatasetGenerator(SyntheticDatasetGenerator):
             "hyper_volume": self.make_hv_dataset,
         }
         if dataset_type not in dataset_function_options.keys():
+            raise ValueError(
+                f"dataset_type must be one of {set(dataset_function_options.keys())}"
+            )
             dataset_type = "medoid"
         self.dataset_function = dataset_function_options[dataset_type]
 

--- a/csrank/dataset_reader/objectranking/rcv_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/rcv_dataset_reader.py
@@ -18,7 +18,7 @@ class RCVDatasetReader(DatasetReader):
         n_objects=5,
         query_based=False,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         super(RCVDatasetReader, self).__init__(
             learning_problem=OBJECT_RANKING, dataset_folder="textual_data", **kwargs

--- a/csrank/dataset_reader/objectranking/tag_genome_object_ranking_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/tag_genome_object_ranking_dataset_reader.py
@@ -13,7 +13,7 @@ class TagGenomeObjectRankingDatasetReader(TagGenomeDatasetReader):
             "critique_fit_less": self.make_critique_fit_dataset(direction=-1),
             "critique_fit_more": self.make_critique_fit_dataset(direction=1),
         }
-        if dataset_type not in dataset_func_dict.keys():
+        if dataset_type not in dataset_func_dict:
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_func_dict.keys())}"
             )

--- a/csrank/dataset_reader/objectranking/tag_genome_object_ranking_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/tag_genome_object_ranking_dataset_reader.py
@@ -14,7 +14,9 @@ class TagGenomeObjectRankingDatasetReader(TagGenomeDatasetReader):
             "critique_fit_more": self.make_critique_fit_dataset(direction=1),
         }
         if dataset_type not in dataset_func_dict.keys():
-            dataset_type = "nearest_neighbour"
+            raise ValueError(
+                f"dataset_type must be one of {set(dataset_func_dict.keys())}"
+            )
         self.logger.info("Dataset type: {}".format(dataset_type))
         self.dataset_function = dataset_func_dict[dataset_type]
 

--- a/csrank/dataset_reader/synthetic_dataset_generator.py
+++ b/csrank/dataset_reader/synthetic_dataset_generator.py
@@ -15,7 +15,7 @@ class SyntheticDatasetGenerator(DatasetReader):
         n_test_instances=10000,
         random_state=None,
         standardize=True,
-        **kwargs
+        **kwargs,
     ):
         super(SyntheticDatasetGenerator, self).__init__(
             learning_problem=learning_problem, dataset_folder=None, **kwargs

--- a/csrank/dataset_reader/tag_genome_reader.py
+++ b/csrank/dataset_reader/tag_genome_reader.py
@@ -36,7 +36,7 @@ class TagGenomeDatasetReader(DatasetReader, metaclass=ABCMeta):
         n_objects=5,
         random_state=None,
         standardize=True,
-        **kwargs
+        **kwargs,
     ):
         super(TagGenomeDatasetReader, self).__init__(
             dataset_folder="movie_lens", **kwargs

--- a/csrank/deprecated/trip_advisor_dataset_reader.py
+++ b/csrank/deprecated/trip_advisor_dataset_reader.py
@@ -76,9 +76,8 @@ class TripAdviosrDataset(object):
     def data_for_city(self, city, features_to_remove=[]):
 
         if city not in self.city_names:
-            raise Exception(
-                "Data is not present for the city, hotel_dataset is present only for: "
-                + repr(self.city_names)
+            raise ValueError(
+                f"Data is not present for the city, hotel_dataset is present only for: {set(self.city_names)}"
             )
         dataframe = copy.deepcopy(self.datasets_dictionaries[city])
         dataframe.drop(features_to_remove, axis=1, inplace=True)

--- a/csrank/deprecated/university_dataset_reader.py
+++ b/csrank/deprecated/university_dataset_reader.py
@@ -147,10 +147,9 @@ def create_joined_dataset():
 def univerisity_dataset_for_year(year):
     dir_name = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
-    if str(year) not in str(years):
-        raise Exception(
-            "Data is not present for the year, university dataset is present only for: "
-            + repr(years)
+    if int(year) not in years:
+        raise ValueError(
+            f"Data is not present for the year, university dataset is present only for: {set(years)}"
         )
     path = os.path.join(dir_name, DATASET_FOLDER, UNIVERSITY_ + str(year) + ".csv")
     dataframe = pd.read_csv(path)

--- a/csrank/discretechoice/cmpnet_discrete_choice.py
+++ b/csrank/discretechoice/cmpnet_discrete_choice.py
@@ -22,7 +22,7 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create an instance of the :class:`CmpNetCore` architecture for learning a discrete choice function.
@@ -86,7 +86,7 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(CmpNetDiscreteChoiceFunction.__name__)
         self.logger.info("Initializing network")
@@ -133,7 +133,7 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden=n_hidden,
@@ -141,5 +141,5 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/discretechoice/fate_discrete_choice.py
+++ b/csrank/discretechoice/fate_discrete_choice.py
@@ -23,7 +23,7 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
         optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATE-network architecture for leaning discrete choice function. The first-aggregate-then-evaluate
@@ -87,7 +87,7 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
             optimizer=optimizer,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FATEDiscreteChoiceFunction.__name__)
 
@@ -157,7 +157,7 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden_set_units=n_hidden_set_units,
@@ -167,5 +167,5 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/discretechoice/fatelinear_discrete_choice.py
+++ b/csrank/discretechoice/fatelinear_discrete_choice.py
@@ -14,7 +14,7 @@ class FATELinearDiscreteChoiceFunction(FATELinearCore, DiscreteObjectChooser):
         learning_rate=1e-3,
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATELinear-network architecture for leaning discrete choice function. The first-aggregate-then-evaluate
@@ -55,7 +55,7 @@ class FATELinearDiscreteChoiceFunction(FATELinearCore, DiscreteObjectChooser):
             batch_size=batch_size,
             loss_function=loss_function,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FATELinearDiscreteChoiceFunction.__name__)
 
@@ -81,7 +81,7 @@ class FATELinearDiscreteChoiceFunction(FATELinearCore, DiscreteObjectChooser):
         batch_size=128,
         epochs_drop=300,
         drop=0.1,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden_set_units=n_hidden_set_units,
@@ -89,5 +89,5 @@ class FATELinearDiscreteChoiceFunction(FATELinearCore, DiscreteObjectChooser):
             batch_size=batch_size,
             epochs_drop=epochs_drop,
             drop=drop,
-            **point
+            **point,
         )

--- a/csrank/discretechoice/feta_discrete_choice.py
+++ b/csrank/discretechoice/feta_discrete_choice.py
@@ -36,7 +36,7 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
         metrics=["categorical_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FETA-network architecture for learning the discrete choice functions.
@@ -103,7 +103,7 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FETADiscreteChoiceFunction.__name__)
 
@@ -342,7 +342,7 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden=n_hidden,
@@ -350,5 +350,5 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/discretechoice/fetalinear_discrete_choice.py
+++ b/csrank/discretechoice/fetalinear_discrete_choice.py
@@ -13,7 +13,7 @@ class FETALinearDiscreteChoiceFunction(FETALinearCore, DiscreteObjectChooser):
         learning_rate=5e-3,
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATELinear-network architecture for leaning discrete choice function. The first-aggregate-then-evaluate
@@ -53,7 +53,7 @@ class FETALinearDiscreteChoiceFunction(FETALinearCore, DiscreteObjectChooser):
             batch_size=batch_size,
             loss_function=loss_function,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FETALinearDiscreteChoiceFunction.__name__)
 
@@ -80,5 +80,5 @@ class FETALinearDiscreteChoiceFunction(FETALinearCore, DiscreteObjectChooser):
             batch_size=batch_size,
             epochs_drop=epochs_drop,
             drop=drop,
-            **point
+            **point,
         )

--- a/csrank/discretechoice/generalized_nested_logit.py
+++ b/csrank/discretechoice/generalized_nested_logit.py
@@ -396,7 +396,7 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
             self.n_nests = self.n_objects_fit + int(self.n_objects_fit / 2)
         else:
             self.n_nests = n_nests
-        if loss_function in likelihood_dict.keys():
+        if loss_function in likelihood_dict:
             self.loss_function = likelihood_dict.get(loss_function, None)
         self.regularization = regularization
         self.model = None

--- a/csrank/discretechoice/generalized_nested_logit.py
+++ b/csrank/discretechoice/generalized_nested_logit.py
@@ -39,7 +39,7 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
         regularization="l2",
         alpha=5e-2,
         random_state=None,
-        **kwd
+        **kwd,
     ):
         """
             Create an instance of the Generalized Nested Logit model for learning the discrete choice function. This
@@ -294,7 +294,7 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
             "method": "advi",
             "callbacks": [CheckParametersConvergence()],
         },
-        **kwargs
+        **kwargs,
     ):
         """
             Fit a generalized nested logit model on the provided set of queries X and choices Y of those objects. The

--- a/csrank/discretechoice/likelihoods.py
+++ b/csrank/discretechoice/likelihoods.py
@@ -146,7 +146,7 @@ def fit_pymc3_model(self, sampler, draws, tune, vi_params, **kwargs):
                 draws=draws,
                 **kwargs,
                 step=pm.Metropolis(),
-                start=start
+                start=start,
             )
     else:
         with self.model:

--- a/csrank/discretechoice/mixed_logit_model.py
+++ b/csrank/discretechoice/mixed_logit_model.py
@@ -254,7 +254,7 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
             point: dict
                 Dictionary containing parameter values which are not tuned for the network
         """
-        if loss_function in likelihood_dict.keys():
+        if loss_function in likelihood_dict:
             self.loss_function = likelihood_dict.get(loss_function, None)
         self.n_mixtures = n_mixtures
         self.regularization = regularization

--- a/csrank/discretechoice/mixed_logit_model.py
+++ b/csrank/discretechoice/mixed_logit_model.py
@@ -177,7 +177,7 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
             "method": "advi",
             "callbacks": [CheckParametersConvergence()],
         },
-        **kwargs
+        **kwargs,
     ):
         """
             Fit a mixed logit model on the provided set of queries X and choices Y of those objects. The provided

--- a/csrank/discretechoice/model_selector.py
+++ b/csrank/discretechoice/model_selector.py
@@ -21,7 +21,7 @@ class ModelSelector(metaclass=ABCMeta):
         model_params,
         fit_params,
         model_path,
-        **kwargs
+        **kwargs,
     ):
         self.priors = [
             [pm.Normal, {"mu": 0, "sd": 10}],

--- a/csrank/discretechoice/multinomial_logit_model.py
+++ b/csrank/discretechoice/multinomial_logit_model.py
@@ -250,7 +250,7 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
             point: dict
                 Dictionary containing parameter values which are not tuned for the network
         """
-        if loss_function in likelihood_dict.keys():
+        if loss_function in likelihood_dict:
             self.loss_function = likelihood_dict.get(loss_function, None)
         self.regularization = regularization
         self.model = None

--- a/csrank/discretechoice/multinomial_logit_model.py
+++ b/csrank/discretechoice/multinomial_logit_model.py
@@ -176,7 +176,7 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
             "method": "advi",
             "callbacks": [CheckParametersConvergence()],
         },
-        **kwargs
+        **kwargs,
     ):
         """
             Fit a multinomial logit model on the provided set of queries X and choices Y of those objects. The

--- a/csrank/discretechoice/nested_logit_model.py
+++ b/csrank/discretechoice/nested_logit_model.py
@@ -457,7 +457,7 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
         else:
             self.n_nests = n_nests
         self.regularization = regularization
-        if loss_function in likelihood_dict.keys():
+        if loss_function in likelihood_dict:
             self.loss_function = likelihood_dict.get(loss_function, None)
         self.cluster_model = None
         self.features_nests = None

--- a/csrank/discretechoice/nested_logit_model.py
+++ b/csrank/discretechoice/nested_logit_model.py
@@ -39,7 +39,7 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
         regularization="l1",
         alpha=1e-2,
         random_state=None,
-        **kwd
+        **kwd,
     ):
         """
             Create an instance of the Nested Logit model for learning the discrete choice function. This model divides
@@ -353,7 +353,7 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
             "method": "advi",
             "callbacks": [CheckParametersConvergence()],
         },
-        **kwargs
+        **kwargs,
     ):
         """
             Fit a nested logit model on the provided set of queries X and choices Y of those objects. The provided

--- a/csrank/discretechoice/paired_combinatorial_logit.py
+++ b/csrank/discretechoice/paired_combinatorial_logit.py
@@ -373,7 +373,7 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
         """
         if alpha is not None:
             self.alpha = alpha
-        if loss_function in likelihood_dict.keys():
+        if loss_function in likelihood_dict:
             self.loss_function = likelihood_dict.get(loss_function, None)
         self.regularization = regularization
         self.model = None

--- a/csrank/discretechoice/paired_combinatorial_logit.py
+++ b/csrank/discretechoice/paired_combinatorial_logit.py
@@ -38,7 +38,7 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
         regularization="l2",
         alpha=5e-2,
         random_state=None,
-        **kwd
+        **kwd,
     ):
         """
             Create an instance of the Paired Combinatorial Logit model for learning the discrete choice function. This
@@ -283,7 +283,7 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
             "method": "advi",
             "callbacks": [CheckParametersConvergence()],
         },
-        **kwargs
+        **kwargs,
     ):
         """
            Fit a paired combinatorial logit  model on the provided set of queries X and choices Y of those objects. The

--- a/csrank/discretechoice/pairwise_discrete_choice.py
+++ b/csrank/discretechoice/pairwise_discrete_choice.py
@@ -13,7 +13,7 @@ class PairwiseSVMDiscreteChoiceFunction(PairwiseSVM, DiscreteObjectChooser):
         normalize=True,
         fit_intercept=True,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create an instance of the :class:`PairwiseSVM` model for learning a discrete choice function.
@@ -53,7 +53,7 @@ class PairwiseSVMDiscreteChoiceFunction(PairwiseSVM, DiscreteObjectChooser):
             normalize=normalize,
             fit_intercept=fit_intercept,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(PairwiseSVMDiscreteChoiceFunction.__name__)
         self.logger.info("Initializing network")

--- a/csrank/discretechoice/ranknet_discrete_choice.py
+++ b/csrank/discretechoice/ranknet_discrete_choice.py
@@ -22,7 +22,7 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create an instance of the :class:`RankNetCore` architecture for learning a choice function.
@@ -82,7 +82,7 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(RankNetDiscreteChoiceFunction.__name__)
         self.logger.info("Initializing network")
@@ -130,7 +130,7 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden=n_hidden,
@@ -138,5 +138,5 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/layers.py
+++ b/csrank/layers.py
@@ -86,7 +86,7 @@ class DeepSet(object):
         kernel_initializer="lecun_normal",
         kernel_regularizer=None,
         input_shape=None,
-        **kwargs
+        **kwargs,
     ):
         self.logger = logging.getLogger("DeepSets")
         self.n_units = units
@@ -106,7 +106,7 @@ class DeepSet(object):
             kernel_initializer=kernel_initializer,
             kernel_regularizer=kernel_regularizer,
             activation=activation,
-            **kwargs
+            **kwargs,
         )
 
     def _construct_layers(self, **kwargs):

--- a/csrank/objectranking/cmp_net.py
+++ b/csrank/objectranking/cmp_net.py
@@ -24,7 +24,7 @@ class CmpNet(CmpNetCore, ObjectRanker):
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create an instance of the :class:`CmpNetCore` architecture for learning a object ranking function.
@@ -91,7 +91,7 @@ class CmpNet(CmpNetCore, ObjectRanker):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(CmpNet.__name__)
         self.logger.info("Initializing network")
@@ -154,7 +154,7 @@ class CmpNet(CmpNetCore, ObjectRanker):
             callbacks=callbacks,
             validation_split=validation_split,
             verbose=verbose,
-            **kwd
+            **kwd,
         )
 
     def _predict_scores_fixed(self, X, **kwargs):
@@ -179,7 +179,7 @@ class CmpNet(CmpNetCore, ObjectRanker):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden=n_hidden,
@@ -187,5 +187,5 @@ class CmpNet(CmpNetCore, ObjectRanker):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/objectranking/expected_rank_regression.py
+++ b/csrank/objectranking/expected_rank_regression.py
@@ -24,7 +24,7 @@ class ExpectedRankRegression(ObjectRanker, Learner):
         normalize=True,
         fit_intercept=True,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create an expected rank regression model.

--- a/csrank/objectranking/fate_object_ranker.py
+++ b/csrank/objectranking/fate_object_ranker.py
@@ -24,7 +24,7 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
         loss_function=hinged_rank_loss,
         metrics=[zero_one_rank_loss_for_scores_ties],
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATE-network architecture for leaning object ranking function. The first-aggregate-then-evaluate
@@ -87,7 +87,7 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
             optimizer=optimizer,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FATEObjectRanker.__name__)
 
@@ -122,7 +122,7 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden_set_units=n_hidden_set_units,
@@ -132,5 +132,5 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/objectranking/fatelinear_object_ranker.py
+++ b/csrank/objectranking/fatelinear_object_ranker.py
@@ -13,7 +13,7 @@ class FATELinearObjectRanker(FATELinearCore, ObjectRanker):
         learning_rate=1e-3,
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATELinear-network architecture for leaning discrete choice function. The first-aggregate-then-evaluate
@@ -54,7 +54,7 @@ class FATELinearObjectRanker(FATELinearCore, ObjectRanker):
             batch_size=batch_size,
             loss_function=loss_function,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FATELinearObjectRanker.__name__)
 
@@ -91,7 +91,7 @@ class FATELinearObjectRanker(FATELinearCore, ObjectRanker):
             callbacks=callbacks,
             validation_split=validation_split,
             verbose=verbose,
-            **kwd
+            **kwd,
         )
 
     def _predict_scores_fixed(self, X, **kwargs):
@@ -113,7 +113,7 @@ class FATELinearObjectRanker(FATELinearCore, ObjectRanker):
         batch_size=128,
         epochs_drop=300,
         drop=0.1,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden_set_units=n_hidden_set_units,
@@ -121,5 +121,5 @@ class FATELinearObjectRanker(FATELinearCore, ObjectRanker):
             batch_size=batch_size,
             epochs_drop=epochs_drop,
             drop=drop,
-            **point
+            **point,
         )

--- a/csrank/objectranking/feta_object_ranker.py
+++ b/csrank/objectranking/feta_object_ranker.py
@@ -27,7 +27,7 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
         metrics=None,
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FETA-network architecture for object ranking. The first-evaluate-then-aggregate approach
@@ -93,7 +93,7 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FETAObjectRanker.__name__)
 
@@ -133,7 +133,7 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
             callbacks=callbacks,
             validation_split=validation_split,
             verbose=verbose,
-            **kwd
+            **kwd,
         )
 
     def _predict_scores_fixed(self, X, **kwargs):
@@ -159,7 +159,7 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden=n_hidden,
@@ -167,5 +167,5 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/objectranking/fetalinear_object_ranker.py
+++ b/csrank/objectranking/fetalinear_object_ranker.py
@@ -12,7 +12,7 @@ class FETALinearObjectRanker(FETALinearCore, ObjectRanker):
         learning_rate=5e-3,
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create a FATELinear-network architecture for leaning discrete choice function. The first-aggregate-then-evaluate
@@ -52,7 +52,7 @@ class FETALinearObjectRanker(FETALinearCore, ObjectRanker):
             batch_size=batch_size,
             loss_function=loss_function,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(FETALinearObjectRanker.__name__)
 
@@ -89,7 +89,7 @@ class FETALinearObjectRanker(FETALinearCore, ObjectRanker):
             callbacks=callbacks,
             validation_split=validation_split,
             verbose=verbose,
-            **kwd
+            **kwd,
         )
 
     def _predict_scores_fixed(self, X, **kwargs):
@@ -112,5 +112,5 @@ class FETALinearObjectRanker(FETALinearCore, ObjectRanker):
             batch_size=batch_size,
             epochs_drop=epochs_drop,
             drop=drop,
-            **point
+            **point,
         )

--- a/csrank/objectranking/list_net.py
+++ b/csrank/objectranking/list_net.py
@@ -38,7 +38,7 @@ class ListNet(Learner, ObjectRanker):
         metrics=[zero_one_rank_loss_for_scores_ties],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """ Create an instance of the ListNet architecture. ListNet trains a latent utility model based on
             top-k-subrankings of the objects. This network learns a latent utility score for each object in the given
@@ -174,7 +174,7 @@ class ListNet(Learner, ObjectRanker):
             kernel_regularizer=self.kernel_regularizer,
             kernel_initializer=self.kernel_initializer,
             activation=self.activation,
-            **self.kwargs
+            **self.kwargs,
         )
         self.logger.debug("Creating top-k dataset")
         X, Y = self._create_topk(X, Y)
@@ -191,7 +191,7 @@ class ListNet(Learner, ObjectRanker):
             callbacks=callbacks,
             validation_split=validation_split,
             verbose=verbose,
-            **kwd
+            **kwd,
         )
         self.logger.debug("Fitting Complete")
 
@@ -279,7 +279,7 @@ class ListNet(Learner, ObjectRanker):
                 kernel_regularizer=self.kernel_regularizer,
                 kernel_initializer=self.kernel_initializer,
                 activation=self.activation,
-                **self.kwargs
+                **self.kwargs,
             )
             self.model = self.construct_model()
             self.model.load_weights(self.hash_file)
@@ -293,7 +293,7 @@ class ListNet(Learner, ObjectRanker):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         """
             Set tunable parameters of the ListNet network to the values provided.
@@ -323,7 +323,7 @@ class ListNet(Learner, ObjectRanker):
             kernel_regularizer=self.kernel_regularizer,
             kernel_initializer=self.kernel_initializer,
             activation=self.activation,
-            **self.kwargs
+            **self.kwargs,
         )
 
         self._scoring_model = None

--- a/csrank/objectranking/rank_net.py
+++ b/csrank/objectranking/rank_net.py
@@ -24,7 +24,7 @@ class RankNet(RankNetCore, ObjectRanker):
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """ Create an instance of the :class:`RankNetCore` architecture for learning a object ranking function.
             It breaks the preferences into pairwise comparisons and learns a latent utility model for the objects.
@@ -84,7 +84,7 @@ class RankNet(RankNetCore, ObjectRanker):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(RankNet.__name__)
         self.logger.info("Initializing network")
@@ -147,7 +147,7 @@ class RankNet(RankNetCore, ObjectRanker):
             callbacks=callbacks,
             validation_split=validation_split,
             verbose=verbose,
-            **kwd
+            **kwd,
         )
 
     def _predict_scores_fixed(self, X, **kwargs):
@@ -172,7 +172,7 @@ class RankNet(RankNetCore, ObjectRanker):
         reg_strength=1e-4,
         learning_rate=1e-3,
         batch_size=128,
-        **point
+        **point,
     ):
         super().set_tunable_parameters(
             n_hidden=n_hidden,
@@ -180,5 +180,5 @@ class RankNet(RankNetCore, ObjectRanker):
             reg_strength=reg_strength,
             learning_rate=learning_rate,
             batch_size=batch_size,
-            **point
+            **point,
         )

--- a/csrank/objectranking/rank_svm.py
+++ b/csrank/objectranking/rank_svm.py
@@ -15,7 +15,7 @@ class RankSVM(ObjectRanker, PairwiseSVM):
         normalize=True,
         fit_intercept=True,
         random_state=None,
-        **kwargs
+        **kwargs,
     ):
         """
             Create an instance of the :class:`PairwiseSVM` model for learning a object ranking function.
@@ -52,7 +52,7 @@ class RankSVM(ObjectRanker, PairwiseSVM):
             normalize=normalize,
             fit_intercept=fit_intercept,
             random_state=random_state,
-            **kwargs
+            **kwargs,
         )
         self.logger = logging.getLogger(RankSVM.__name__)
         self.logger.info("Initializing network")

--- a/csrank/tests/test_callbacks.py
+++ b/csrank/tests/test_callbacks.py
@@ -57,9 +57,7 @@ def test_callbacks(trivial_classification_problem, name):
         step = math.floor(epochs / epochs_drop)
         actual_lr = init_lr * math.pow(drop, step)
         key = (
-            "learning_rate"
-            if "learning_rate" in model.optimizer.get_config().keys()
-            else "lr"
+            "learning_rate" if "learning_rate" in model.optimizer.get_config() else "lr"
         )
         learning_rate = model.optimizer.get_config().get(key, 0.0)
         assert np.isclose(

--- a/csrank/tests/test_fate.py
+++ b/csrank/tests/test_fate.py
@@ -59,11 +59,7 @@ def test_construction_core():
     assert grc.batch_size == params["batch_size"]
     rtol = 1e-2
     atol = 1e-4
-    key = (
-        "learning_rate"
-        if "learning_rate" in grc.optimizer.get_config().keys()
-        else "lr"
-    )
+    key = "learning_rate" if "learning_rate" in grc.optimizer.get_config() else "lr"
     learning_rate = grc.optimizer.get_config().get(key, 0.0)
     assert np.isclose(
         learning_rate, params["learning_rate"], rtol=rtol, atol=atol, equal_nan=False

--- a/csrank/tests/test_ranking.py
+++ b/csrank/tests/test_ranking.py
@@ -63,7 +63,7 @@ def trivial_ranking_problem():
 
 def check_params_tunable(tunable_obj, params, rtol=1e-2, atol=1e-4):
     for key, value in params.items():
-        if key in tunable_obj.__dict__.keys():
+        if key in tunable_obj.__dict__:
             expected = tunable_obj.__dict__[key]
             if isinstance(value, int) or isinstance(value, float):
                 if (
@@ -79,20 +79,17 @@ def check_params_tunable(tunable_obj, params, rtol=1e-2, atol=1e-4):
                     )
             else:
                 assert value == expected
-        elif key == "learning_rate" and "optimizer" in tunable_obj.__dict__.keys():
+        elif key == "learning_rate" and "optimizer" in tunable_obj.__dict__:
             key = (
                 "learning_rate"
-                if "learning_rate" in tunable_obj.optimizer.get_config().keys()
+                if "learning_rate" in tunable_obj.optimizer.get_config()
                 else "lr"
             )
             learning_rate = tunable_obj.optimizer.get_config().get(key, 0.0)
             assert np.isclose(
                 learning_rate, value, rtol=rtol, atol=atol, equal_nan=False
             )
-        elif (
-            key == "reg_strength"
-            and "kernel_regularizer" in tunable_obj.__dict__.keys()
-        ):
+        elif key == "reg_strength" and "kernel_regularizer" in tunable_obj.__dict__:
             config = tunable_obj.kernel_regularizer.get_config()
             val1 = np.isclose(
                 config["l1"], value, rtol=rtol, atol=atol, equal_nan=False

--- a/csrank/tests/test_ranking.py
+++ b/csrank/tests/test_ranking.py
@@ -63,8 +63,8 @@ def trivial_ranking_problem():
 
 def check_params_tunable(tunable_obj, params, rtol=1e-2, atol=1e-4):
     for key, value in params.items():
-        if key in tunable_obj.__dict__:
-            expected = tunable_obj.__dict__[key]
+        if hasattr(tunable_obj, key):
+            expected = getattr(tunable_obj, key)
             if isinstance(value, int) or isinstance(value, float):
                 if (
                     isinstance(tunable_obj, PairedCombinatorialLogit)
@@ -79,7 +79,7 @@ def check_params_tunable(tunable_obj, params, rtol=1e-2, atol=1e-4):
                     )
             else:
                 assert value == expected
-        elif key == "learning_rate" and "optimizer" in tunable_obj.__dict__:
+        elif key == "learning_rate" and hasattr(tunable_obj, "optimizer"):
             key = (
                 "learning_rate"
                 if "learning_rate" in tunable_obj.optimizer.get_config()
@@ -89,7 +89,7 @@ def check_params_tunable(tunable_obj, params, rtol=1e-2, atol=1e-4):
             assert np.isclose(
                 learning_rate, value, rtol=rtol, atol=atol, equal_nan=False
             )
-        elif key == "reg_strength" and "kernel_regularizer" in tunable_obj.__dict__:
+        elif key == "reg_strength" and hasattr(tunable_obj, "kernel_regularizer"):
             config = tunable_obj.kernel_regularizer.get_config()
             val1 = np.isclose(
                 config["l1"], value, rtol=rtol, atol=atol, equal_nan=False

--- a/csrank/tuning.py
+++ b/csrank/tuning.py
@@ -86,7 +86,7 @@ class ParameterOptimizer(Learner):
         tuning_callbacks=None,
         validation_loss=None,
         learning_problem=OBJECT_RANKING,
-        **kwd
+        **kwd,
     ):
         """
 
@@ -237,7 +237,7 @@ class ParameterOptimizer(Learner):
         n_iter=100,
         cv_iter=None,
         acq_func="gp_hedge",
-        **kwargs
+        **kwargs,
     ):
         start = datetime.now()
         self.random_state_ = check_random_state(self.random_state)
@@ -497,7 +497,7 @@ class ParameterOptimizer(Learner):
                 random_state=opt_seed,
                 base_estimator=base_estimator,
                 acq_func=acq_func,
-                **kwargs
+                **kwargs,
             )
 
         return n_iter


### PR DESCRIPTION
## Description

Fixes https://github.com/kiudee/cs-ranking/issues/122. I think I caught all instances, I verified this by grepping for ` not in `.

I kind of think most of those should either pass the function directly in the first place or use an enum instead. Either way, this change should be an improvement.

This is technically a breaking change, though practically not really important since it only changes behaviour in already broken code.

While working on this I noticed some surprising black behaviour (explained in the commit message), which I fixed in a separate commit.

## Motivation and Context

#122 

## How Has This Been Tested?

Ran the testsuite and pre-commit hooks.

## Does this close/impact existing issues?

Fixes #122.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
