### PR TITLE
Properly pass on fit kwargs to the core network

### DIFF
--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -74,7 +74,9 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
             random_state : int or object
                 Numpy random state
             **kwargs
-                Keyword arguments for the @FATENetwork
+                Further keyword arguments for the @FATENetwork. See the
+                documentation of :func:`~csrank.core.FATENetwork.fit` for more
+                information.
         """
         self.loss_function = loss_function
         self.metrics = metrics
@@ -132,21 +134,7 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
         return super().construct_model(n_features, n_objects)
 
     def fit(
-        self,
-        X,
-        Y,
-        epochs=35,
-        inner_epochs=1,
-        callbacks=None,
-        validation_split=0.1,
-        verbose=0,
-        global_lr=1.0,
-        global_momentum=0.9,
-        min_bucket_size=500,
-        refit=False,
-        tune_size=0.1,
-        thin_thresholds=1,
-        **kwargs,
+        self, X, Y, verbose=0, tune_size=0.1, thin_thresholds=1, **kwargs,
     ):
         """
             Fit a generic FATE-network model for learning a choice function on a provided set of queries.
@@ -163,33 +151,16 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
             Y : numpy array or dict
                 Choices for given objects in the query
                 (n_instances, n_objects) if numpy array or map from n_objects to numpy arrays
-            epochs : int
-                Number of epochs to run if training for a fixed query size or
-                number of epochs of the meta gradient descent for the variadic model
-            inner_epochs : int
-                Number of epochs to train for each query size inside the variadic
-                model
-            callbacks : list
-                List of callbacks to be called during optimization
-            validation_split : float (range : [0,1])
-                Percentage of instances to split off to validate on
             verbose : bool
                 Print verbose information
-            global_lr : float
-                Learning rate of the meta gradient descent (variadic model only)
-            global_momentum : float
-                Momentum for the meta gradient descent (variadic model only)
-            min_bucket_size : int
-                Restrict the training to queries of a minimum size
-            refit : bool
-                If True, create a new model object, otherwise continue fitting the
-                existing one if one exists.
             tune_size: float (range : [0,1])
-                Percentage of instances to split off to tune the threshold for the choice function
+                Percentage of instances to split off to tune the threshold
             thin_thresholds: int
                 The number of instances of scores to skip while tuning the threshold
             **kwargs :
-                Keyword arguments for the fit function
+                Further keyword arguments for the @FATENetwork. See the
+                documentation of :func:`~csrank.core.FATENetwork.fit` for more
+                information.
         """
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(

--- a/csrank/core/fate_network.py
+++ b/csrank/core/fate_network.py
@@ -309,6 +309,45 @@ class FATENetwork(FATENetworkCore):
         optimizer=None,
         **kwargs,
     ):
+        """
+            Fit a generic FATE-network model.
+
+            This is not intended for direct use. Instead, you should use one of
+            the domain-specific subclasses such as `FATEChoiceFuntion` or
+            `FATEObjectRanker` instead.
+
+            Parameters
+            ----------
+            X : numpy array or dict
+                Feature vectors of the objects
+                (n_instances, n_objects, n_features) if numpy array or map from n_objects to numpy arrays
+            Y : numpy array or dict
+                The exact semantics are domain dependent and should be
+                described in the relevant subclasses.
+            epochs : int
+                Number of epochs to run if training for a fixed query size or
+                number of epochs of the meta gradient descent for the variadic model
+            inner_epochs : int
+                Number of epochs to train for each query size inside the variadic
+                model
+            callbacks : list
+                List of callbacks to be called during optimization
+            validation_split : float (range : [0,1])
+                Percentage of instances to split off to validate on
+            verbose : bool
+                Print verbose information
+            global_lr : float
+                Learning rate of the meta gradient descent (variadic model only)
+            global_momentum : float
+                Momentum for the meta gradient descent (variadic model only)
+            min_bucket_size : int
+                Restrict the training to queries of a minimum size
+            refit : bool
+                If True, create a new model object, otherwise continue fitting the
+                existing one if one exists.
+            **kwargs :
+                Keyword arguments for the fit function
+        """
         if optimizer is not None:
             self.optimizer = optimizer
         if isinstance(X, dict):

--- a/csrank/tests/test_choice_functions.py
+++ b/csrank/tests/test_choice_functions.py
@@ -49,7 +49,7 @@ choice_functions = {
             "n_hidden_set_units": 5,
             "optimizer": optimizer,
         },
-        get_vals([0.8185, 0.6845, 0.9924]),
+        get_vals([0.8185, 0.6070, 0.9924]),
     ),
     FATELINEAR_CHOICE: (
         FATELinearChoiceFunction,


### PR DESCRIPTION
## Description

Previously we were passing on **kwargs, but also specifying some
arguments explicitly which meant they were not included in **kwargs and
not passed on.

To make this more maintainable, we now also delegate the documentation
to the core.

## Motivation and Context

#126 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Does this close/impact existing issues?

Fixes #126

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
