### PR TITLE
Raise ValueError on some more unknown variants

### DIFF
--- a/csrank/choicefunction/generalized_linear_model.py
+++ b/csrank/choicefunction/generalized_linear_model.py
@@ -64,10 +64,12 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
                 [2] Kenneth Train. Qualitative choice analysis. Cambridge, MA: MIT Press, 1986
         """
         self.logger = logging.getLogger(GeneralizedLinearModel.__name__)
-        if regularization in ["l1", "l2"]:
-            self.regularization = regularization
-        else:
-            self.regularization = "l2"
+        known_regularization_functions = {"l1", "l2"}
+        if regularization not in known_regularization_functions:
+            raise ValueError(
+                f"Regularization function {regularization} is unknown. Must be one of {known_regularization_functions}"
+            )
+        self.regularization = regularization
         self.random_state = random_state
         self.model = None
         self.trace = None

--- a/csrank/discretechoice/generalized_nested_logit.py
+++ b/csrank/discretechoice/generalized_nested_logit.py
@@ -95,10 +95,12 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
         self.loss_function = likelihood_dict.get(loss_function, None)
 
         self.random_state = random_state
-        if regularization in ["l1", "l2"]:
-            self.regularization = regularization
-        else:
-            self.regularization = "l2"
+        known_regularization_functions = {"l1", "l2"}
+        if regularization not in known_regularization_functions:
+            raise ValueError(
+                f"Regularization function {regularization} is unknown. Must be one of {known_regularization_functions}"
+            )
+        self.regularization = regularization
         self._config = None
         self.model = None
         self.trace = None
@@ -371,7 +373,7 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
         return DiscreteObjectChooser.predict_for_scores(self, scores, **kwargs)
 
     def set_tunable_parameters(
-        self, alpha=None, n_nests=None, loss_function="", regularization="l2", **point
+        self, alpha=None, n_nests=None, loss_function=None, regularization="l2", **point
     ):
         """
             Set tunable parameters of the Nested Logit model to the values provided.
@@ -396,7 +398,11 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
             self.n_nests = self.n_objects_fit + int(self.n_objects_fit / 2)
         else:
             self.n_nests = n_nests
-        if loss_function in likelihood_dict:
+        if loss_function is not None:
+            if loss_function not in likelihood_dict:
+                raise ValueError(
+                    f"Loss function {loss_function} is unknown. Must be one of {set(likelihood_dict.keys())}"
+                )
             self.loss_function = likelihood_dict.get(loss_function, None)
         self.regularization = regularization
         self.model = None

--- a/csrank/discretechoice/mixed_logit_model.py
+++ b/csrank/discretechoice/mixed_logit_model.py
@@ -73,10 +73,12 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
         """
         self.logger = logging.getLogger(MixedLogitModel.__name__)
         self.loss_function = likelihood_dict.get(loss_function, None)
-        if regularization in ["l1", "l2"]:
-            self.regularization = regularization
-        else:
-            self.regularization = "l2"
+        known_regularization_functions = {"l1", "l2"}
+        if regularization not in known_regularization_functions:
+            raise ValueError(
+                f"Regularization function {regularization} is unknown. Must be one of {known_regularization_functions}"
+            )
+        self.regularization = regularization
         self._config = None
         self.n_mixtures = n_mixtures
         self.model = None

--- a/csrank/discretechoice/multinomial_logit_model.py
+++ b/csrank/discretechoice/multinomial_logit_model.py
@@ -65,10 +65,12 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
         """
         self.logger = logging.getLogger(MultinomialLogitModel.__name__)
         self.loss_function = likelihood_dict.get(loss_function, None)
-        if regularization in ["l1", "l2"]:
-            self.regularization = regularization
-        else:
-            self.regularization = "l2"
+        known_regularization_functions = {"l1", "l2"}
+        if regularization not in known_regularization_functions:
+            raise ValueError(
+                f"Regularization function {regularization} is unknown. Must be one of {known_regularization_functions}"
+            )
+        self.regularization = regularization
         self._config = None
         self.model = None
         self.trace = None
@@ -237,7 +239,7 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
     def predict_for_scores(self, scores, **kwargs):
         return DiscreteObjectChooser.predict_for_scores(self, scores, **kwargs)
 
-    def set_tunable_parameters(self, loss_function="", regularization="l1", **point):
+    def set_tunable_parameters(self, loss_function=None, regularization="l1", **point):
         """
             Set tunable parameters of the Multinomial Logit model to the values provided.
 
@@ -250,7 +252,11 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
             point: dict
                 Dictionary containing parameter values which are not tuned for the network
         """
-        if loss_function in likelihood_dict:
+        if loss_function is not None:
+            if loss_function not in likelihood_dict:
+                raise ValueError(
+                    f"Loss function {loss_function} is unknown. Must be one of {set(likelihood_dict.keys())}"
+                )
             self.loss_function = likelihood_dict.get(loss_function, None)
         self.regularization = regularization
         self.model = None

--- a/csrank/discretechoice/nested_logit_model.py
+++ b/csrank/discretechoice/nested_logit_model.py
@@ -92,10 +92,12 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
         self.alpha = alpha
         self.random_state = random_state
         self.loss_function = likelihood_dict.get(loss_function, None)
-        if regularization in ["l1", "l2"]:
-            self.regularization = regularization
-        else:
-            self.regularization = "l2"
+        known_regularization_functions = {"l1", "l2"}
+        if regularization not in known_regularization_functions:
+            raise ValueError(
+                f"Regularization function {regularization} is unknown. Must be one of {known_regularization_functions}"
+            )
+        self.regularization = regularization
         self._config = None
         self.cluster_model = None
         self.features_nests = None
@@ -432,7 +434,7 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
         return DiscreteObjectChooser.predict_for_scores(self, scores, **kwargs)
 
     def set_tunable_parameters(
-        self, alpha=None, n_nests=None, loss_function="", regularization="l1", **point
+        self, alpha=None, n_nests=None, loss_function=None, regularization="l1", **point
     ):
         """
             Set tunable parameters of the Nested Logit model to the values provided.
@@ -457,7 +459,11 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
         else:
             self.n_nests = n_nests
         self.regularization = regularization
-        if loss_function in likelihood_dict:
+        if loss_function is not None:
+            if loss_function not in likelihood_dict:
+                raise ValueError(
+                    f"Loss function {loss_function} is unknown. Must be one of {set(likelihood_dict.keys())}"
+                )
             self.loss_function = likelihood_dict.get(loss_function, None)
         self.cluster_model = None
         self.features_nests = None

--- a/csrank/discretechoice/paired_combinatorial_logit.py
+++ b/csrank/discretechoice/paired_combinatorial_logit.py
@@ -92,10 +92,12 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
         self.alpha = alpha
         self.random_state = random_state
         self.loss_function = likelihood_dict.get(loss_function, None)
-        if regularization in ["l1", "l2"]:
-            self.regularization = regularization
-        else:
-            self.regularization = "l2"
+        known_regularization_functions = {"l1", "l2"}
+        if regularization not in known_regularization_functions:
+            raise ValueError(
+                f"Regularization function {regularization} is unknown. Must be one of {known_regularization_functions}"
+            )
+        self.regularization = regularization
         self._config = None
         self.model = None
         self.trace = None
@@ -355,7 +357,7 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
         return DiscreteObjectChooser.predict_for_scores(self, scores, **kwargs)
 
     def set_tunable_parameters(
-        self, alpha=5e-2, loss_function="", regularization="l2", **point
+        self, alpha=5e-2, loss_function=None, regularization="l2", **point
     ):
         """
             Set tunable parameters of the Paired Combinatorial logit model to the values provided.
@@ -373,7 +375,11 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
         """
         if alpha is not None:
             self.alpha = alpha
-        if loss_function in likelihood_dict:
+        if loss_function is not None:
+            if loss_function not in likelihood_dict:
+                raise ValueError(
+                    f"Loss function {loss_function} is unknown. Must be one of {set(likelihood_dict.keys())}"
+                )
             self.loss_function = likelihood_dict.get(loss_function, None)
         self.regularization = regularization
         self.model = None


### PR DESCRIPTION
## Description

Continuation of ab058621e836ec230d27b516f9f53fbfc063d28f. In that commit
I only searched for the `not in` pattern, but the cases fixed here
actually check the reverse.


## Motivation and Context

#128 

## How Has This Been Tested?

Testsuite & pre-commit hooks.

## Does this close/impact existing issues?

Fixes #128. Technically a breaking change, but only exposes pre-existing bugs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
