### PR TITLE
Fix baseline choice parameter

### DIFF
--- a/csrank/choicefunction/baseline.py
+++ b/csrank/choicefunction/baseline.py
@@ -67,7 +67,7 @@ class AllPositive(ChoiceFunctions, Learner):
                 )
 
         else:
-            scores = self._predict_scores_fixed(X, **kwargs)
+            scores = self._predict_scores_fixed(X, Y, **kwargs)
         return scores
 
     def predict_for_scores(self, scores, **kwargs):

--- a/csrank/choicefunction/baseline.py
+++ b/csrank/choicefunction/baseline.py
@@ -34,6 +34,14 @@ class AllPositive(ChoiceFunctions, Learner):
                or a single numpy array of size:
                (n_instances, n_objects, n_features)
 
+            Y : dict or numpy array
+               Dictionary with a mapping from ranking size to numpy arrays
+               or a single numpy array of size:
+               (n_instances, n_objects, n_features)
+               True scores
+
+            Note that dict and array parameters cannot be mixed.
+
            Returns
            -------
            Y : dict or numpy array
@@ -43,6 +51,13 @@ class AllPositive(ChoiceFunctions, Learner):
                Predicted scores
         """
         self.logger.info("Predicting scores")
+
+        if (isinstance(X, dict) and not isinstance(Y, dict)) or (
+            isinstance(X, np.ndarray) and not isinstance(Y, np.ndarray)
+        ):
+            raise ValueError(
+                "X and Y need to have matching types, either both have to be a dict or both a numpy array."
+            )
 
         if isinstance(X, dict):
             scores = dict()

--- a/csrank/choicefunction/baseline.py
+++ b/csrank/choicefunction/baseline.py
@@ -8,10 +8,11 @@ from .choice_functions import ChoiceFunctions
 
 class AllPositive(ChoiceFunctions, Learner):
     def __init__(self, **kwargs):
-        """
-            Baseline assigns the average number of chosen objects in the given choice sets and chooses all the objects.
+        """Baseline that assigns the average number of chosen objects in the given choice sets and chooses all the objects
 
-            :param kwargs: Keyword arguments for the algorithms
+        Parameters
+        ----------
+        **kwargs: Keyword arguments for the algorithms
         """
 
         self.logger = logging.getLogger(AllPositive.__name__)
@@ -24,31 +25,30 @@ class AllPositive(ChoiceFunctions, Learner):
         return np.zeros_like(Y) + Y.mean()
 
     def predict_scores(self, X, Y, **kwargs):
-        """
-           Predict the utility scores for each object in the collection of set of objects.
+        """Predict the utility scores for each object in the collection of set of objects
 
-            Parameters
-            ----------
-            X : dict or numpy array
-               Dictionary with a mapping from ranking size to numpy arrays
-               or a single numpy array of size:
-               (n_instances, n_objects, n_features)
+        Parameters
+        ----------
+        X : dict or numpy array
+           Dictionary with a mapping from ranking size to numpy arrays
+           or a single numpy array of size:
+           (n_instances, n_objects, n_features)
 
-            Y : dict or numpy array
-               Dictionary with a mapping from ranking size to numpy arrays
-               or a single numpy array of size:
-               (n_instances, n_objects, n_features)
-               True scores
+        Y : dict or numpy array
+           Dictionary with a mapping from ranking size to numpy arrays
+           or a single numpy array of size:
+           (n_instances, n_objects, n_features)
+           True scores
 
-            Note that dict and array parameters cannot be mixed.
+        Note that dict and array parameters cannot be mixed.
 
-           Returns
-           -------
-           Y : dict or numpy array
-               Dictionary with a mapping from ranking size to numpy arrays
-               or a single numpy array of size:
-               (n_instances, n_objects)
-               Predicted scores
+        Returns
+        -------
+        Y : dict or numpy array
+            Dictionary with a mapping from ranking size to numpy arrays
+            or a single numpy array of size:
+            (n_instances, n_objects)
+            Predicted scores
         """
         self.logger.info("Predicting scores")
 


### PR DESCRIPTION
## Description

I believe this fixes #127, though I'm not entirely sure what the intended behaviour of the baseline choice function is. Why does it expect `Y` on `predict`? Even if it is a baseline and simply predicts the mean, shouldn't it take `Y` on fit instead?

## Motivation and Context

#127

## How Has This Been Tested?

Testsuite, pre-commit hooks.

## Does this close/impact existing issues?

Fixes #127.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
