### PR TITLE
Do not override the optimizer's default parameters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,9 @@ History
 Unreleased
 ------------------
 
-No changes yet.
+* We no longer override any of the defaults of our default optimizer (SGD). In
+  particular, the parameters nesterov, momentum and lr are now set to the
+  default values set by keras.
 
 1.2.1 (2020-06-08)
 ------------------

--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -19,7 +19,7 @@ class CmpNetChoiceFunction(CmpNetCore, ChoiceFunctions):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,

--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -21,7 +21,7 @@ class FATEChoiceFunction(FATENetwork, ChoiceFunctions):
         activation="selu",
         kernel_initializer="lecun_normal",
         kernel_regularizer=l2(0.01),
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         batch_size=256,
         metrics=None,
         random_state=None,

--- a/csrank/choicefunction/feta_choice.py
+++ b/csrank/choicefunction/feta_choice.py
@@ -34,7 +34,7 @@ class FETAChoiceFunction(FETANetwork, ChoiceFunctions):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="selu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,

--- a/csrank/choicefunction/ranknet_choice.py
+++ b/csrank/choicefunction/ranknet_choice.py
@@ -19,7 +19,7 @@ class RankNetChoiceFunction(RankNetCore, ChoiceFunctions):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,

--- a/csrank/core/cmpnet_core.py
+++ b/csrank/core/cmpnet_core.py
@@ -29,7 +29,7 @@ class CmpNetCore(Learner):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,

--- a/csrank/core/fate_network.py
+++ b/csrank/core/fate_network.py
@@ -29,7 +29,7 @@ class FATENetworkCore(Learner):
         activation="selu",
         kernel_initializer="lecun_normal",
         kernel_regularizer=l2(0.01),
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         batch_size=256,
         random_state=None,
         **kwargs,

--- a/csrank/core/feta_network.py
+++ b/csrank/core/feta_network.py
@@ -36,7 +36,7 @@ class FETANetwork(Learner):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="selu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=None,
         batch_size=256,
         random_state=None,

--- a/csrank/core/ranknet_core.py
+++ b/csrank/core/ranknet_core.py
@@ -28,7 +28,7 @@ class RankNetCore(Learner):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,

--- a/csrank/discretechoice/cmpnet_discrete_choice.py
+++ b/csrank/discretechoice/cmpnet_discrete_choice.py
@@ -18,7 +18,7 @@ class CmpNetDiscreteChoiceFunction(CmpNetCore, DiscreteObjectChooser):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,

--- a/csrank/discretechoice/fate_discrete_choice.py
+++ b/csrank/discretechoice/fate_discrete_choice.py
@@ -20,7 +20,7 @@ class FATEDiscreteChoiceFunction(FATENetwork, DiscreteObjectChooser):
         activation="selu",
         kernel_initializer="lecun_normal",
         kernel_regularizer=l2(0.01),
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         batch_size=256,
         random_state=None,
         **kwargs,

--- a/csrank/discretechoice/feta_discrete_choice.py
+++ b/csrank/discretechoice/feta_discrete_choice.py
@@ -32,7 +32,7 @@ class FETADiscreteChoiceFunction(FETANetwork, DiscreteObjectChooser):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="selu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["categorical_accuracy"],
         batch_size=256,
         random_state=None,

--- a/csrank/discretechoice/ranknet_discrete_choice.py
+++ b/csrank/discretechoice/ranknet_discrete_choice.py
@@ -18,7 +18,7 @@ class RankNetDiscreteChoiceFunction(RankNetCore, DiscreteObjectChooser):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,

--- a/csrank/objectranking/cmp_net.py
+++ b/csrank/objectranking/cmp_net.py
@@ -20,7 +20,7 @@ class CmpNet(CmpNetCore, ObjectRanker):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,

--- a/csrank/objectranking/fate_object_ranker.py
+++ b/csrank/objectranking/fate_object_ranker.py
@@ -19,7 +19,7 @@ class FATEObjectRanker(FATENetwork, ObjectRanker):
         activation="selu",
         kernel_initializer="lecun_normal",
         kernel_regularizer=l2(0.01),
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         batch_size=256,
         loss_function=hinged_rank_loss,
         metrics=[zero_one_rank_loss_for_scores_ties],

--- a/csrank/objectranking/feta_object_ranker.py
+++ b/csrank/objectranking/feta_object_ranker.py
@@ -23,7 +23,7 @@ class FETAObjectRanker(FETANetwork, ObjectRanker):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="selu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=None,
         batch_size=256,
         random_state=None,

--- a/csrank/objectranking/list_net.py
+++ b/csrank/objectranking/list_net.py
@@ -34,7 +34,7 @@ class ListNet(Learner, ObjectRanker):
         kernel_regularizer=l2(1e-4),
         activation="selu",
         kernel_initializer="lecun_normal",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=[zero_one_rank_loss_for_scores_ties],
         batch_size=256,
         random_state=None,

--- a/csrank/objectranking/rank_net.py
+++ b/csrank/objectranking/rank_net.py
@@ -20,7 +20,7 @@ class RankNet(RankNetCore, ObjectRanker):
         kernel_regularizer=l2(1e-4),
         kernel_initializer="lecun_normal",
         activation="relu",
-        optimizer=SGD(lr=1e-4, nesterov=True, momentum=0.9),
+        optimizer=SGD(),
         metrics=["binary_accuracy"],
         batch_size=256,
         random_state=None,


### PR DESCRIPTION
## Description

As discussed in https://github.com/kiudee/cs-ranking/pull/119. The
reasoning is that we don't have good reason to override those, the
library user will likely have to tune them anyways (or use a different
optimizer altogether). At the same time, they make the design proposed
in #119 (passing uninitialized optimizers and their parameters
separately) more difficult.


## Motivation and Context

https://github.com/kiudee/cs-ranking/pull/119#issuecomment-639525631

## How Has This Been Tested?

Tests & pre-commit hooks.

## Does this close/impact existing issues?

Part of #119 and thus part of #116.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
