### PR TITLE
Do not initialize the model in init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+    - 3.7 # Pinned since tensorflow 1.x is not available for python > 3.7
 
 cache:
   directories:

--- a/csrank/choicefunction/baseline.py
+++ b/csrank/choicefunction/baseline.py
@@ -16,7 +16,6 @@ class AllPositive(ChoiceFunctions, Learner):
         """
 
         self.logger = logging.getLogger(AllPositive.__name__)
-        self.model = None
 
     def fit(self, X, Y, **kwd):
         pass

--- a/csrank/choicefunction/generalized_linear_model.py
+++ b/csrank/choicefunction/generalized_linear_model.py
@@ -71,7 +71,6 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
             )
         self.regularization = regularization
         self.random_state = random_state
-        self.model = None
         self.trace = None
         self.trace_vi = None
         self.Xt = None

--- a/csrank/core/cmpnet_core.py
+++ b/csrank/core/cmpnet_core.py
@@ -52,7 +52,6 @@ class CmpNetCore(Learner):
                 del kwargs[key]
         self.kwargs = kwargs
         self.random_state = random_state
-        self.model = None
 
     def _construct_layers(self, **kwargs):
 
@@ -158,10 +157,10 @@ class CmpNetCore(Learner):
             activation=self.activation,
             **self.kwargs,
         )
-        self.model = self.construct_model()
+        self.model_ = self.construct_model()
 
         self.logger.debug("Finished Creating the model, now fitting started")
-        self.model.fit(
+        self.model_.fit(
             [x1, x2],
             y_double,
             batch_size=self.batch_size,
@@ -174,7 +173,7 @@ class CmpNetCore(Learner):
         self.logger.debug("Fitting Complete")
 
     def predict_pair(self, a, b, **kwargs):
-        return self.model.predict([a, b], **kwargs)
+        return self.model_.predict([a, b], **kwargs)
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_instances, n_objects, n_features = X.shape

--- a/csrank/core/fate_network.py
+++ b/csrank/core/fate_network.py
@@ -175,7 +175,6 @@ class FATENetwork(FATENetworkCore):
 
         self.n_hidden_set_layers = n_hidden_set_layers
         self.n_hidden_set_units = n_hidden_set_units
-        self.model = None
         self.set_layer = None
         self._create_set_layers(
             activation=self.activation,
@@ -249,7 +248,7 @@ class FATENetwork(FATENetworkCore):
             else:
                 weights = self.models_[n_objects].get_weights()
         else:
-            weights = self.model.get_weights()
+            weights = self.model_.get_weights()
         return weights
 
     def set_weights(self, weights, n_objects=None):
@@ -259,7 +258,7 @@ class FATENetwork(FATENetworkCore):
             else:
                 self.models_[0].set_weights(weights)
         else:
-            self.model.set_weights(weights)
+            self.model_.set_weights(weights)
 
     def _fit(
         self,
@@ -381,16 +380,16 @@ class FATENetwork(FATENetworkCore):
         else:
             self.is_variadic = False
 
-            if self.model is None or refit:
+            if not hasattr(self, "model_") or refit:
                 if generator is not None:
                     X, Y = next(iter(generator))
 
                 n_inst, n_objects, n_features = X.shape
 
-                self.model = self.construct_model(n_features, n_objects)
+                self.model_ = self.construct_model(n_features, n_objects)
             self.logger.info("Fitting started")
             if generator is None:
-                self.model.fit(
+                self.model_.fit(
                     x=X,
                     y=Y,
                     callbacks=callbacks,
@@ -401,7 +400,7 @@ class FATENetwork(FATENetworkCore):
                     **kwargs,
                 )
             else:
-                self.model.fit_generator(
+                self.model_.fit_generator(
                     generator=generator,
                     callbacks=callbacks,
                     epochs=epochs,

--- a/csrank/core/feta_network.py
+++ b/csrank/core/feta_network.py
@@ -60,7 +60,6 @@ class FETANetwork(Learner):
                 del kwargs[key]
         self.kwargs = kwargs
         self._pairwise_model = None
-        self.model = None
         self._zero_order_model = None
 
     @property
@@ -292,10 +291,10 @@ class FETANetwork(Learner):
         self.random_state_ = check_random_state(self.random_state)
 
         X, Y = self.sub_sampling(X, Y)
-        self.model = self.construct_model()
+        self.model_ = self.construct_model()
         self.logger.debug("Starting gradient descent...")
 
-        self.model.fit(
+        self.model_.fit(
             x=X,
             y=Y,
             batch_size=self.batch_size,
@@ -331,6 +330,6 @@ class FETANetwork(Learner):
         if self.n_objects_fit_ != n_objects:
             scores = self._predict_scores_using_pairs(X, **kwargs)
         else:
-            scores = self.model.predict(X, **kwargs)
+            scores = self.model_.predict(X, **kwargs)
         self.logger.info("Done predicting scores")
         return scores

--- a/csrank/core/pairwise_svm.py
+++ b/csrank/core/pairwise_svm.py
@@ -53,7 +53,6 @@ class PairwiseSVM(Learner):
         self.random_state = random_state
         self.fit_intercept = fit_intercept
         self.weights = None
-        self.model = None
 
     def fit(self, X, Y, **kwargs):
         """
@@ -74,7 +73,7 @@ class PairwiseSVM(Learner):
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         x_train, y_single = self._convert_instances_(X, Y)
         if self.use_logistic_regression:
-            self.model = LogisticRegression(
+            self.model_ = LogisticRegression(
                 C=self.C,
                 tol=self.tol,
                 fit_intercept=self.fit_intercept,
@@ -82,7 +81,7 @@ class PairwiseSVM(Learner):
             )
             self.logger.info("Logistic Regression model ")
         else:
-            self.model = LinearSVC(
+            self.model_ = LinearSVC(
                 C=self.C,
                 tol=self.tol,
                 fit_intercept=self.fit_intercept,
@@ -95,10 +94,10 @@ class PairwiseSVM(Learner):
             x_train = std_scalar.fit_transform(x_train)
         self.logger.debug("Finished Creating the model, now fitting started")
 
-        self.model.fit(x_train, y_single)
-        self.weights = self.model.coef_.flatten()
+        self.model_.fit(x_train, y_single)
+        self.weights = self.model_.coef_.flatten()
         if self.fit_intercept:
-            self.weights = np.append(self.weights, self.model.intercept_)
+            self.weights = np.append(self.weights, self.model_.intercept_)
         self.logger.debug("Fitting Complete")
 
     def _predict_scores_fixed(self, X, **kwargs):

--- a/csrank/core/ranknet_core.py
+++ b/csrank/core/ranknet_core.py
@@ -47,7 +47,6 @@ class RankNetCore(Learner):
         self.kwargs = kwargs
         self.batch_size = batch_size
         self._scoring_model = None
-        self.model = None
         self.random_state = random_state
 
     def _construct_layers(self, **kwargs):
@@ -152,10 +151,10 @@ class RankNetCore(Learner):
         )
 
         # Model with input as two objects and output as probability of x1>x2
-        self.model = self.construct_model()
+        self.model_ = self.construct_model()
         self.logger.debug("Finished Creating the model, now fitting started")
 
-        self.model.fit(
+        self.model_.fit(
             [X1, X2],
             Y_single,
             batch_size=self.batch_size,

--- a/csrank/discretechoice/baseline.py
+++ b/csrank/discretechoice/baseline.py
@@ -16,7 +16,6 @@ class RandomBaselineDC(DiscreteObjectChooser, Learner):
 
         self.logger = logging.getLogger(RandomBaselineDC.__name__)
         self.random_state = random_state
-        self.model = None
 
     def fit(self, X, Y, **kwd):
         self.random_state_ = check_random_state(self.random_state)

--- a/csrank/discretechoice/generalized_nested_logit.py
+++ b/csrank/discretechoice/generalized_nested_logit.py
@@ -102,7 +102,6 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
             )
         self.regularization = regularization
         self._config = None
-        self.model = None
         self.trace = None
         self.trace_vi = None
         self.Xt = None

--- a/csrank/discretechoice/mixed_logit_model.py
+++ b/csrank/discretechoice/mixed_logit_model.py
@@ -81,7 +81,6 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
         self.regularization = regularization
         self._config = None
         self.n_mixtures = n_mixtures
-        self.model = None
         self.trace = None
         self.trace_vi = None
         self.Xt = None

--- a/csrank/discretechoice/multinomial_logit_model.py
+++ b/csrank/discretechoice/multinomial_logit_model.py
@@ -72,7 +72,6 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
             )
         self.regularization = regularization
         self._config = None
-        self.model = None
         self.trace = None
         self.trace_vi = None
         self.Xt = None

--- a/csrank/discretechoice/nested_logit_model.py
+++ b/csrank/discretechoice/nested_logit_model.py
@@ -101,7 +101,6 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
         self._config = None
         self.cluster_model = None
         self.features_nests = None
-        self.model = None
         self.trace = None
         self.trace_vi = None
         self.Xt = None

--- a/csrank/discretechoice/paired_combinatorial_logit.py
+++ b/csrank/discretechoice/paired_combinatorial_logit.py
@@ -99,7 +99,6 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
             )
         self.regularization = regularization
         self._config = None
-        self.model = None
         self.trace = None
         self.trace_vi = None
         self.Xt = None

--- a/csrank/dyadranking/fate_dyad_ranker.py
+++ b/csrank/dyadranking/fate_dyad_ranker.py
@@ -8,7 +8,7 @@ class FATEDyadRanker(FATENetwork, DyadRanker):
         pass
 
     def predict_scores(self, Xo, Xc, **kwargs):
-        return self.model.predict([Xo, Xc], **kwargs)
+        return self.model_.predict([Xo, Xc], **kwargs)
 
     def predict(self, Xo, Xc, **kwargs):
         s = self.predict_scores(Xo, Xc, **kwargs)

--- a/csrank/objectranking/baseline.py
+++ b/csrank/objectranking/baseline.py
@@ -16,7 +16,6 @@ class RandomBaselineRanker(ObjectRanker, Learner):
 
         self.logger = logging.getLogger(RandomBaselineRanker.__name__)
         self.random_state = (random_state,)
-        self.model = None
 
     def fit(self, X, Y, **kwd):
         self.random_state_ = check_random_state(self.random_state)

--- a/csrank/objectranking/expected_rank_regression.py
+++ b/csrank/objectranking/expected_rank_regression.py
@@ -93,13 +93,13 @@ class ExpectedRankRegression(ObjectRanker, Learner):
         x_train, y_train = complete_linear_regression_dataset(X, Y)
         self.logger.debug("Finished the Dataset")
         if self.alpha < 1e-3:
-            self.model = LinearRegression(
+            self.model_ = LinearRegression(
                 normalize=self.normalize, fit_intercept=self.fit_intercept
             )
             self.logger.info("LinearRegression")
         else:
             if self.l1_ratio >= 0.01:
-                self.model = ElasticNet(
+                self.model_ = ElasticNet(
                     alpha=self.alpha,
                     l1_ratio=self.l1_ratio,
                     normalize=self.normalize,
@@ -109,7 +109,7 @@ class ExpectedRankRegression(ObjectRanker, Learner):
                 )
                 self.logger.info("Elastic Net")
             else:
-                self.model = Ridge(
+                self.model_ = Ridge(
                     alpha=self.alpha,
                     normalize=self.normalize,
                     tol=self.tol,
@@ -118,10 +118,10 @@ class ExpectedRankRegression(ObjectRanker, Learner):
                 )
                 self.logger.info("Ridge")
         self.logger.debug("Finished Creating the model, now fitting started")
-        self.model.fit(x_train, y_train)
-        self.weights = self.model.coef_.flatten()
+        self.model_.fit(x_train, y_train)
+        self.weights = self.model_.coef_.flatten()
         if self.fit_intercept:
-            self.weights = np.append(self.weights, self.model.intercept_)
+            self.weights = np.append(self.weights, self.model_.intercept_)
         self.logger.debug("Fitting Complete")
 
     def _predict_scores_fixed(self, X, **kwargs):
@@ -130,7 +130,7 @@ class ExpectedRankRegression(ObjectRanker, Learner):
             "For Test instances {} objects {} features {}".format(*X.shape)
         )
         X1 = X.reshape(n_instances * n_objects, n_features)
-        scores = n_objects - self.model.predict(X1)
+        scores = n_objects - self.model_.predict(X1)
         scores = scores.reshape(n_instances, n_objects)
         scores = normalize(scores)
         self.logger.info("Done predicting scores")

--- a/csrank/objectranking/list_net.py
+++ b/csrank/objectranking/list_net.py
@@ -103,7 +103,6 @@ class ListNet(ObjectRanker, Learner):
 
         self.batch_size = batch_size
         self.random_state = random_state
-        self.model = None
         self._scoring_model = None
 
     def _construct_layers(self, **kwargs):
@@ -178,9 +177,9 @@ class ListNet(ObjectRanker, Learner):
         self.logger.debug("Finished creating the dataset")
 
         self.logger.debug("Creating the model")
-        self.model = self.construct_model()
+        self.model_ = self.construct_model()
         self.logger.debug("Finished creating the model, now fitting...")
-        self.model.fit(
+        self.model_.fit(
             X,
             Y,
             batch_size=self.batch_size,


### PR DESCRIPTION
## Description

The model inherently is an "attribute that [has] been estimated from the
data"[1], i.e. it should be initialized in fit and have a trailing
underscore.

[1] https://scikit-learn.org/stable/developers/develop.html#rolling-your-own-estimator

## Motivation and Context

Working on only saving the model parameters in init to make sure our estimators are stateless and match the scikit-learn estimator spec.

## How Has This Been Tested?

Tests + pre-commit.

## Does this close/impact existing issues?

Related #94, #116.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
