### PR TITLE
Move logger initialization to the module level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - . ./scripts/install_miniconda.sh
 
 install:
+  - PYTHON_VERSION=3.7
   - . ./scripts/create_testenv.sh
   - pip install codecov
   - conda install --yes sphinx ipython

--- a/csrank/callbacks.py
+++ b/csrank/callbacks.py
@@ -5,6 +5,8 @@ from keras import backend as K
 from keras.callbacks import Callback
 import numpy as np
 
+logger = logging.getLogger(__name__)
+
 
 class EarlyStoppingWithWeights(Callback):
     def __init__(
@@ -77,7 +79,6 @@ class EarlyStoppingWithWeights(Callback):
             self.min_delta *= 1
         else:
             self.min_delta *= -1
-        self.logger = logging.getLogger(EarlyStoppingWithWeights.__name__)
 
     def on_train_begin(self, logs=None):
         # Allow instances to be re-used
@@ -93,7 +94,7 @@ class EarlyStoppingWithWeights(Callback):
         current = logs.get(self.monitor)
         self.best_weights = self.model.get_weights()
         if current is None:
-            self.logger.warning(
+            logger.warning(
                 "Early stopping conditioned on metric `%s` which is not available. Available metrics are: %s"
                 % (self.monitor, ",".join(list(logs.keys()))),
                 RuntimeWarning,
@@ -110,7 +111,7 @@ class EarlyStoppingWithWeights(Callback):
 
     def on_train_end(self, logs=None):
         if self.stopped_epoch > 0:
-            self.logger.info(
+            logger.info(
                 "Setting best weights for final epoch {}".format(self.stopped_epoch)
             )
             self.model.set_weights(self.best_weights)
@@ -136,7 +137,6 @@ class LRScheduler(Callback):
         self.epochs_drop = epochs_drop
         self.drop = drop
         self.initial_lr = None
-        self.logger = logging.getLogger(LRScheduler.__name__)
 
     def step_decay(self, epoch):
         """The step-decay function, which takes the current epoch and update the learning rate according to the
@@ -190,10 +190,9 @@ class DebugOutput(Callback):
         super(DebugOutput, self).__init__(**kwargs)
         self.delta = delta
         self.epoch = 0
-        self.logger = logging.getLogger(DebugOutput.__name__)
 
     def on_train_end(self, logs=None):
-        self.logger.debug("Total number of epochs: {}".format(self.epoch))
+        logger.debug("Total number of epochs: {}".format(self.epoch))
 
     def on_train_begin(self, logs=None):
         self.epoch = 0
@@ -201,4 +200,4 @@ class DebugOutput(Callback):
     def on_epoch_end(self, epoch, logs=None):
         self.epoch += 1
         if self.epoch % self.delta == 0:
-            self.logger.debug("Epoch {} of the training finished.".format(self.epoch))
+            logger.debug("Epoch {} of the training finished.".format(self.epoch))

--- a/csrank/choicefunction/baseline.py
+++ b/csrank/choicefunction/baseline.py
@@ -5,6 +5,8 @@ import numpy as np
 from csrank.learner import Learner
 from .choice_functions import ChoiceFunctions
 
+logger = logging.getLogger(__name__)
+
 
 class AllPositive(ChoiceFunctions, Learner):
     def __init__(self, **kwargs):
@@ -14,8 +16,6 @@ class AllPositive(ChoiceFunctions, Learner):
         ----------
         **kwargs: Keyword arguments for the algorithms
         """
-
-        self.logger = logging.getLogger(AllPositive.__name__)
 
     def fit(self, X, Y, **kwd):
         pass
@@ -49,7 +49,7 @@ class AllPositive(ChoiceFunctions, Learner):
             (n_instances, n_objects)
             Predicted scores
         """
-        self.logger.info("Predicting scores")
+        logger.info("Predicting scores")
 
         if (isinstance(X, dict) and not isinstance(Y, dict)) or (
             isinstance(X, np.ndarray) and not isinstance(Y, np.ndarray)

--- a/csrank/choicefunction/choice_functions.py
+++ b/csrank/choicefunction/choice_functions.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta
+import logging
 
 import numpy as np
 
@@ -7,6 +8,7 @@ from csrank.metrics_np import f1_measure
 from csrank.util import progress_bar
 
 __all__ = ["ChoiceFunctions"]
+logger = logging.getLogger(__name__)
 
 
 class ChoiceFunctions(metaclass=ABCMeta):
@@ -61,8 +63,8 @@ class ChoiceFunctions(metaclass=ABCMeta):
                 if verbose == 1:
                     progress_bar(i, len(probabilities), status="Tuning threshold")
         except KeyboardInterrupt:
-            self.logger.info("Keyboard interrupted")
-        self.logger.info(
+            logger.info("Keyboard interrupted")
+        logger.info(
             "Tuned threshold, obtained {:.2f} which achieved"
             " a micro F1-measure of {:.2f}".format(threshold, best)
         )

--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -8,6 +8,8 @@ from csrank.choicefunction.choice_functions import ChoiceFunctions
 from csrank.choicefunction.util import generate_complete_pairwise_dataset
 from csrank.core.cmpnet_core import CmpNetCore
 
+logger = logging.getLogger(__name__)
+
 
 class CmpNetChoiceFunction(ChoiceFunctions, CmpNetCore):
     def __init__(
@@ -92,15 +94,14 @@ class CmpNetChoiceFunction(ChoiceFunctions, CmpNetCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(CmpNetChoiceFunction.__name__)
-        self.logger.info("Initializing network")
+        logger.info("Initializing network")
         self.threshold = 0.5
 
     def _convert_instances_(self, X, Y):
-        self.logger.debug("Creating the Dataset")
+        logger.debug("Creating the Dataset")
         x1, x2, garbage, y_double, garbage = generate_complete_pairwise_dataset(X, Y)
         del garbage
-        self.logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
+        logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
         return x1, x2, y_double
 
     def fit(
@@ -166,7 +167,7 @@ class CmpNetChoiceFunction(ChoiceFunctions, CmpNetCore):
                     **kwd,
                 )
             finally:
-                self.logger.info(
+                logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
         else:

--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -9,6 +9,8 @@ from sklearn.model_selection import train_test_split
 from csrank.core.fate_network import FATENetwork
 from .choice_functions import ChoiceFunctions
 
+logger = logging.getLogger(__name__)
+
 
 class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
     def __init__(
@@ -95,7 +97,6 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FATEChoiceFunction.__name__)
         self.threshold = 0.5
 
     def _construct_layers(self, **kwargs):
@@ -111,7 +112,7 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
             **kwargs
                 Keyword arguments passed into the joint layers
         """
-        self.logger.info(
+        logger.info(
             "Construct joint layers hidden units {} and layers {} ".format(
                 self.n_hidden_joint_units, self.n_hidden_joint_layers
             )
@@ -124,7 +125,7 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
                     self.n_hidden_joint_units, name="joint_layer_{}".format(i), **kwargs
                 )
             )
-        self.logger.info("Construct output score node")
+        logger.info("Construct output score node")
         self.scorer = Dense(
             1,
             name="output_node",
@@ -168,7 +169,7 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
             try:
                 super().fit(X_train, Y_train, **kwargs)
             finally:
-                self.logger.info(
+                logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
                 self.threshold = self._tune_threshold(

--- a/csrank/choicefunction/fatelinear_choice.py
+++ b/csrank/choicefunction/fatelinear_choice.py
@@ -6,6 +6,8 @@ from sklearn.model_selection import train_test_split
 from csrank.core.fate_linear import FATELinearCore
 from .choice_functions import ChoiceFunctions
 
+logger = logging.getLogger(__name__)
+
 
 class FATELinearChoiceFunction(ChoiceFunctions, FATELinearCore):
     def __init__(
@@ -58,7 +60,6 @@ class FATELinearChoiceFunction(ChoiceFunctions, FATELinearCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FATELinearChoiceFunction.__name__)
 
     def fit(
         self,
@@ -87,7 +88,7 @@ class FATELinearChoiceFunction(ChoiceFunctions, FATELinearCore):
                     **kwd,
                 )
             finally:
-                self.logger.info(
+                logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
                 self.threshold = self._tune_threshold(

--- a/csrank/choicefunction/fetalinear_choice.py
+++ b/csrank/choicefunction/fetalinear_choice.py
@@ -6,6 +6,8 @@ from sklearn.model_selection import train_test_split
 from csrank.core.feta_linear import FETALinearCore
 from .choice_functions import ChoiceFunctions
 
+logger = logging.getLogger(__name__)
+
 
 class FETALinearChoiceFunction(ChoiceFunctions, FETALinearCore):
     def __init__(
@@ -56,7 +58,6 @@ class FETALinearChoiceFunction(ChoiceFunctions, FETALinearCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FETALinearChoiceFunction.__name__)
 
     def fit(
         self,
@@ -85,7 +86,7 @@ class FETALinearChoiceFunction(ChoiceFunctions, FETALinearCore):
                     **kwd,
                 )
             finally:
-                self.logger.info(
+                logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
                 self.threshold = self._tune_threshold(

--- a/csrank/choicefunction/generalized_linear_model.py
+++ b/csrank/choicefunction/generalized_linear_model.py
@@ -28,6 +28,8 @@ except ImportError:
 
     raise MissingExtraError("theano", "probabilistic")
 
+logger = logging.getLogger(__name__)
+
 
 class GeneralizedLinearModel(ChoiceFunctions, Learner):
     def __init__(self, regularization="l2", random_state=None, **kwargs):
@@ -63,7 +65,6 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
 
                 [2] Kenneth Train. Qualitative choice analysis. Cambridge, MA: MIT Press, 1986
         """
-        self.logger = logging.getLogger(GeneralizedLinearModel.__name__)
         known_regularization_functions = {"l1", "l2"}
         if regularization not in known_regularization_functions:
             raise ValueError(
@@ -116,7 +117,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
                 },
             ]
         }
-        self.logger.info(
+        logger.info(
             "Creating default config {}".format(print_dictionary(configuration))
         )
         return configuration
@@ -144,7 +145,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
             -------
              model : pymc3 Model :class:`pm.Model`
         """
-        self.logger.info(
+        logger.info(
             "Creating model_args config {}".format(
                 print_dictionary(self.model_configuration)
             )
@@ -159,7 +160,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
             utility = tt.dot(self.Xt, weights_dict["weights"]) + intercept
             self.p = ttu.sigmoid(utility)
             BinaryCrossEntropyLikelihood("yl", p=self.p, observed=self.Yt)
-        self.logger.info("Model construction completed")
+        logger.info("Model construction completed")
 
     def fit(
         self,
@@ -230,7 +231,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
                     X_train, Y_train, sampler=sampler, vi_params=vi_params, **kwargs
                 )
             finally:
-                self.logger.info(
+                logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
                 self.threshold = self._tune_threshold(

--- a/csrank/choicefunction/pairwise_choice.py
+++ b/csrank/choicefunction/pairwise_choice.py
@@ -6,6 +6,8 @@ from csrank.core.pairwise_svm import PairwiseSVM
 from .choice_functions import ChoiceFunctions
 from .util import generate_complete_pairwise_dataset
 
+logger = logging.getLogger(__name__)
+
 
 class PairwiseSVMChoiceFunction(ChoiceFunctions, PairwiseSVM):
     def __init__(
@@ -58,12 +60,11 @@ class PairwiseSVMChoiceFunction(ChoiceFunctions, PairwiseSVM):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(PairwiseSVMChoiceFunction.__name__)
-        self.logger.info("Initializing network")
+        logger.info("Initializing network")
         self.threshold = 0.5
 
     def _convert_instances_(self, X, Y):
-        self.logger.debug("Creating the Dataset")
+        logger.debug("Creating the Dataset")
         (
             garbage,
             garbage,
@@ -73,9 +74,7 @@ class PairwiseSVMChoiceFunction(ChoiceFunctions, PairwiseSVM):
         ) = generate_complete_pairwise_dataset(X, Y)
         del garbage
         assert x_train.shape[1] == self.n_object_features_fit_
-        self.logger.debug(
-            "Finished the Dataset with instances {}".format(x_train.shape[0])
-        )
+        logger.debug("Finished the Dataset with instances {}".format(x_train.shape[0]))
         return x_train, y_single
 
     def fit(self, X, Y, tune_size=0.1, thin_thresholds=1, verbose=0, **kwd):
@@ -107,7 +106,7 @@ class PairwiseSVMChoiceFunction(ChoiceFunctions, PairwiseSVM):
             try:
                 super().fit(X_train, Y_train, **kwd)
             finally:
-                self.logger.info(
+                logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
                 self.threshold = self._tune_threshold(

--- a/csrank/choicefunction/ranknet_choice.py
+++ b/csrank/choicefunction/ranknet_choice.py
@@ -8,6 +8,8 @@ from csrank.core.ranknet_core import RankNetCore
 from .choice_functions import ChoiceFunctions
 from .util import generate_complete_pairwise_dataset
 
+logger = logging.getLogger(__name__)
+
 
 class RankNetChoiceFunction(ChoiceFunctions, RankNetCore):
     def __init__(
@@ -86,15 +88,14 @@ class RankNetChoiceFunction(ChoiceFunctions, RankNetCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(RankNetChoiceFunction.__name__)
-        self.logger.info("Initializing network")
+        logger.info("Initializing network")
         self.threshold = 0.5
 
     def _convert_instances_(self, X, Y):
-        self.logger.debug("Creating the Dataset")
+        logger.debug("Creating the Dataset")
         x1, x2, garbage, garbage, y_single = generate_complete_pairwise_dataset(X, Y)
         del garbage
-        self.logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
+        logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
         return x1, x2, y_single
 
     def fit(
@@ -157,7 +158,7 @@ class RankNetChoiceFunction(ChoiceFunctions, RankNetCore):
                     **kwd,
                 )
             finally:
-                self.logger.info(
+                logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
                 self.threshold = self._tune_threshold(

--- a/csrank/core/cmpnet_core.py
+++ b/csrank/core/cmpnet_core.py
@@ -14,6 +14,8 @@ from csrank.constants import allowed_dense_kwargs
 from csrank.layers import NormalizedDense
 from csrank.learner import Learner
 
+logger = logging.getLogger(__name__)
+
 
 class CmpNetCore(Learner):
     def __init__(
@@ -31,7 +33,6 @@ class CmpNetCore(Learner):
         random_state=None,
         **kwargs,
     ):
-        self.logger = logging.getLogger("CmpNet")
         self.batch_normalization = batch_normalization
         self.activation = activation
 
@@ -93,7 +94,7 @@ class CmpNetCore(Learner):
         self._initialize_regularizer()
         x1x2 = concatenate([self.x1, self.x2])
         x2x1 = concatenate([self.x2, self.x1])
-        self.logger.debug("Creating the model")
+        logger.debug("Creating the model")
         for hidden in self.hidden_layers:
             x1x2 = hidden(x1x2)
             x2x1 = hidden(x2x1)
@@ -150,7 +151,7 @@ class CmpNetCore(Learner):
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         x1, x2, y_double = self._convert_instances_(X, Y)
 
-        self.logger.debug("Instances created {}".format(x1.shape[0]))
+        logger.debug("Instances created {}".format(x1.shape[0]))
         self._construct_layers(
             kernel_regularizer=self.kernel_regularizer_,
             kernel_initializer=self.kernel_initializer,
@@ -159,7 +160,7 @@ class CmpNetCore(Learner):
         )
         self.model_ = self.construct_model()
 
-        self.logger.debug("Finished Creating the model, now fitting started")
+        logger.debug("Finished Creating the model, now fitting started")
         self.model_.fit(
             [x1, x2],
             y_double,
@@ -170,16 +171,14 @@ class CmpNetCore(Learner):
             verbose=verbose,
             **kwd,
         )
-        self.logger.debug("Fitting Complete")
+        logger.debug("Fitting Complete")
 
     def predict_pair(self, a, b, **kwargs):
         return self.model_.predict([a, b], **kwargs)
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_instances, n_objects, n_features = X.shape
-        self.logger.info(
-            "Test Set instances {} objects {} features {}".format(*X.shape)
-        )
+        logger.info("Test Set instances {} objects {} features {}".format(*X.shape))
         n2 = n_objects * (n_objects - 1)
         pairs = np.empty((n2, 2, n_features))
         scores = np.empty((n_instances, n_objects))
@@ -190,6 +189,6 @@ class CmpNetCore(Learner):
             scores[n] = result.reshape(n_objects, n_objects - 1).mean(axis=1)
             del result
         del pairs
-        self.logger.info("Done predicting scores")
+        logger.info("Done predicting scores")
 
         return scores

--- a/csrank/core/fate_linear.py
+++ b/csrank/core/fate_linear.py
@@ -1,3 +1,4 @@
+import logging
 import math
 
 from keras.losses import binary_crossentropy
@@ -8,6 +9,8 @@ import tensorflow as tf
 from csrank.learner import Learner
 from csrank.numpy_util import sigmoid
 from csrank.util import progress_bar
+
+logger = logging.getLogger(__name__)
 
 
 class FATELinearCore(Learner):
@@ -102,7 +105,7 @@ class FATELinearCore(Learner):
             tf_session.run(init)
             self._fit_(X, Y, epochs, n_instances, tf_session, verbose)
             training_cost = tf_session.run(self.loss, feed_dict={self.X: X, self.Y: Y})
-            self.logger.info(
+            logger.info(
                 "Fitting completed {} epochs done with loss {}".format(
                     epochs, training_cost.mean()
                 )
@@ -128,14 +131,12 @@ class FATELinearCore(Learner):
                     print("Epoch {}: cost {} ".format((epoch + 1), np.mean(c)))
                 if (epoch + 1) % 100 == 0:
                     c = tf_session.run(self.loss, feed_dict={self.X: X, self.Y: Y})
-                    self.logger.info(
-                        "Epoch {}: cost {} ".format((epoch + 1), np.mean(c))
-                    )
+                    logger.info("Epoch {}: cost {} ".format((epoch + 1), np.mean(c)))
                 self.step_decay(epoch)
         except KeyboardInterrupt:
-            self.logger.info("Interrupted")
+            logger.info("Interrupted")
             c = tf_session.run(self.loss, feed_dict={self.X: X, self.Y: Y})
-            self.logger.info("Epoch {}: cost {} ".format((epoch + 1), np.mean(c)))
+            logger.info("Epoch {}: cost {} ".format((epoch + 1), np.mean(c)))
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_instances, n_objects, n_features = X.shape

--- a/csrank/core/feta_linear.py
+++ b/csrank/core/feta_linear.py
@@ -1,4 +1,5 @@
 from itertools import combinations
+import logging
 import math
 
 from keras.losses import binary_crossentropy
@@ -9,6 +10,8 @@ import tensorflow as tf
 from csrank.learner import Learner
 from csrank.numpy_util import sigmoid
 from csrank.util import progress_bar
+
+logger = logging.getLogger(__name__)
 
 
 class FETALinearCore(Learner):
@@ -170,7 +173,7 @@ class FETALinearCore(Learner):
             tf_session.run(init)
             self._fit_(X, Y, epochs, n_instances, tf_session, verbose)
             training_cost = tf_session.run(self.loss, feed_dict={self.X: X, self.Y: Y})
-            self.logger.info(
+            logger.info(
                 "Fitting completed {} epochs done with loss {}".format(
                     epochs, training_cost.mean()
                 )
@@ -197,14 +200,12 @@ class FETALinearCore(Learner):
                     print("Epoch {}: cost {} ".format((epoch + 1), np.mean(c)))
                 if (epoch + 1) % 100 == 0:
                     c = tf_session.run(self.loss, feed_dict={self.X: X, self.Y: Y})
-                    self.logger.info(
-                        "Epoch {}: cost {} ".format((epoch + 1), np.mean(c))
-                    )
+                    logger.info("Epoch {}: cost {} ".format((epoch + 1), np.mean(c)))
                 self.step_decay(epoch)
         except KeyboardInterrupt:
-            self.logger.info("Interrupted")
+            logger.info("Interrupted")
             c = tf_session.run(self.loss, feed_dict={self.X: X, self.Y: Y})
-            self.logger.info("Epoch {}: cost {} ".format((epoch + 1), np.mean(c)))
+            logger.info("Epoch {}: cost {} ".format((epoch + 1), np.mean(c)))
 
     def _predict_scores_fixed(self, X, **kwargs):
         """Predict the scores for a given collection of sets of objects of same size.

--- a/csrank/core/pairwise_svm.py
+++ b/csrank/core/pairwise_svm.py
@@ -8,6 +8,8 @@ from sklearn.utils import check_random_state
 
 from csrank.learner import Learner
 
+logger = logging.getLogger(__name__)
+
 
 class PairwiseSVM(Learner):
     def __init__(
@@ -48,7 +50,6 @@ class PairwiseSVM(Learner):
         self.normalize = normalize
         self.C = C
         self.tol = tol
-        self.logger = logging.getLogger("RankSVM")
         self.use_logistic_regression = use_logistic_regression
         self.random_state = random_state
         self.fit_intercept = fit_intercept
@@ -79,7 +80,7 @@ class PairwiseSVM(Learner):
                 fit_intercept=self.fit_intercept,
                 random_state=self.random_state_,
             )
-            self.logger.info("Logistic Regression model ")
+            logger.info("Logistic Regression model ")
         else:
             self.model_ = LinearSVC(
                 C=self.C,
@@ -87,29 +88,27 @@ class PairwiseSVM(Learner):
                 fit_intercept=self.fit_intercept,
                 random_state=self.random_state_,
             )
-            self.logger.info("Linear SVC model ")
+            logger.info("Linear SVC model ")
 
         if self.normalize:
             std_scalar = StandardScaler()
             x_train = std_scalar.fit_transform(x_train)
-        self.logger.debug("Finished Creating the model, now fitting started")
+        logger.debug("Finished Creating the model, now fitting started")
 
         self.model_.fit(x_train, y_single)
         self.weights = self.model_.coef_.flatten()
         if self.fit_intercept:
             self.weights = np.append(self.weights, self.model_.intercept_)
-        self.logger.debug("Fitting Complete")
+        logger.debug("Fitting Complete")
 
     def _predict_scores_fixed(self, X, **kwargs):
         assert X.shape[-1] == self.n_object_features_fit_
-        self.logger.info(
-            "For Test instances {} objects {} features {}".format(*X.shape)
-        )
+        logger.info("For Test instances {} objects {} features {}".format(*X.shape))
         if self.fit_intercept:
             scores = np.dot(X, self.weights[:-1])
         else:
             scores = np.dot(X, self.weights)
-        self.logger.info("Done predicting scores")
+        logger.info("Done predicting scores")
         return np.array(scores)
 
     def _convert_instances_(self, X, Y):

--- a/csrank/core/ranknet_core.py
+++ b/csrank/core/ranknet_core.py
@@ -13,6 +13,8 @@ from csrank.constants import allowed_dense_kwargs
 from csrank.layers import NormalizedDense
 from csrank.learner import Learner
 
+logger = logging.getLogger(__name__)
+
 
 class RankNetCore(Learner):
     def __init__(
@@ -30,7 +32,6 @@ class RankNetCore(Learner):
         random_state=None,
         **kwargs,
     ):
-        self.logger = logging.getLogger(RankNetCore.__name__)
         self.batch_normalization = batch_normalization
         self.activation = activation
         self.metrics = metrics
@@ -50,7 +51,7 @@ class RankNetCore(Learner):
         self.random_state = random_state
 
     def _construct_layers(self, **kwargs):
-        self.logger.info("n_hidden {}, n_units {}".format(self.n_hidden, self.n_units))
+        logger.info("n_hidden {}, n_units {}".format(self.n_hidden, self.n_units))
         self.x1 = Input(shape=(self.n_object_features_fit_,))
         self.x2 = Input(shape=(self.n_object_features_fit_,))
         self.output_node = Dense(
@@ -138,8 +139,8 @@ class RankNetCore(Learner):
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         X1, X2, Y_single = self._convert_instances_(X, Y)
 
-        self.logger.debug("Instances created {}".format(X1.shape[0]))
-        self.logger.debug("Creating the model")
+        logger.debug("Instances created {}".format(X1.shape[0]))
+        logger.debug("Creating the model")
 
         self._initialize_optimizer()
         self._initialize_regularizer()
@@ -152,7 +153,7 @@ class RankNetCore(Learner):
 
         # Model with input as two objects and output as probability of x1>x2
         self.model_ = self.construct_model()
-        self.logger.debug("Finished Creating the model, now fitting started")
+        logger.debug("Finished Creating the model, now fitting started")
 
         self.model_.fit(
             [X1, X2],
@@ -165,7 +166,7 @@ class RankNetCore(Learner):
             **kwd,
         )
 
-        self.logger.debug("Fitting Complete")
+        logger.debug("Fitting Complete")
 
     @property
     def scoring_model(self):
@@ -177,7 +178,7 @@ class RankNetCore(Learner):
                 Neural network to learn the non-linear utility score
         """
         if self._scoring_model is None:
-            self.logger.info("creating scoring model")
+            logger.info("creating scoring model")
             inp = Input(shape=(self.n_object_features_fit_,))
             x = inp
             for hidden_layer in self.hidden_layers:
@@ -188,11 +189,9 @@ class RankNetCore(Learner):
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_instances, n_objects, n_features = X.shape
-        self.logger.info(
-            "Test Set instances {} objects {} features {}".format(*X.shape)
-        )
+        logger.info("Test Set instances {} objects {} features {}".format(*X.shape))
         X1 = X.reshape(n_instances * n_objects, n_features)
         scores = self.scoring_model.predict(X1, **kwargs)
         scores = scores.reshape(n_instances, n_objects)
-        self.logger.info("Done predicting scores")
+        logger.info("Done predicting scores")
         return scores

--- a/csrank/dataset_reader/choicefunctions/expedia_choice_dataset_reader.py
+++ b/csrank/dataset_reader/choicefunctions/expedia_choice_dataset_reader.py
@@ -7,13 +7,14 @@ from csrank.constants import CHOICE_FUNCTION
 from .util import sub_sampling_choices_from_relevance
 from ..expedia_dataset_reader import ExpediaDatasetReader
 
+logger = logging.getLogger(__name__)
+
 
 class ExpediaChoiceDatasetReader(ExpediaDatasetReader):
     def __init__(self, random_state=None, n_objects=5, **kwargs):
         super(ExpediaChoiceDatasetReader, self).__init__(
             learning_problem=CHOICE_FUNCTION, **kwargs
         )
-        self.logger = logging.getLogger(ExpediaChoiceDatasetReader.__name__)
         self.random_state = check_random_state(random_state)
         self.n_objects = n_objects
         self.hdf5file_path = os.path.join(self.dirname, "exp_choice.h5")

--- a/csrank/dataset_reader/choicefunctions/letor_ranking_choice_dataset_reader.py
+++ b/csrank/dataset_reader/choicefunctions/letor_ranking_choice_dataset_reader.py
@@ -6,13 +6,14 @@ from csrank.constants import CHOICE_FUNCTION
 from .util import sub_sampling_choices_from_relevance
 from ..letor_ranking_dataset_reader import LetorRankingDatasetReader
 
+logger = logging.getLogger(__name__)
+
 
 class LetorRankingChoiceDatasetReader(LetorRankingDatasetReader):
     def __init__(self, random_state=None, n_objects=5, **kwargs):
         super(LetorRankingChoiceDatasetReader, self).__init__(
             learning_problem=CHOICE_FUNCTION, **kwargs
         )
-        self.logger = logging.getLogger(LetorRankingChoiceDatasetReader.__name__)
         self.random_state = check_random_state(random_state)
         self.n_objects = n_objects
         self.__load_dataset__()

--- a/csrank/dataset_reader/choicefunctions/mnist_choice_dataset_reader.py
+++ b/csrank/dataset_reader/choicefunctions/mnist_choice_dataset_reader.py
@@ -1,7 +1,11 @@
+import logging
+
 import numpy as np
 
 from csrank.constants import CHOICE_FUNCTION
 from ..mnist_dataset_reader import MNISTDatasetReader
+
+logger = logging.getLogger(__name__)
 
 
 class MNISTChoiceDatasetReader(MNISTDatasetReader):
@@ -19,10 +23,10 @@ class MNISTChoiceDatasetReader(MNISTDatasetReader):
         super(MNISTChoiceDatasetReader, self).__init__(
             learning_problem=CHOICE_FUNCTION, **kwargs
         )
-        self.logger.info("Dataset type {}".format(dataset_type))
+        logger.info("Dataset type {}".format(dataset_type))
 
     def create_dataset_largest(self):
-        self.logger.info("Largest Dataset")
+        logger.info("Largest Dataset")
         num_classes = len(np.unique(self.y_labels))
         n_total = self.n_test_instances + self.n_train_instances
         largest_numbers = self.random_state.randint(1, num_classes, size=n_total)
@@ -44,7 +48,7 @@ class MNISTChoiceDatasetReader(MNISTDatasetReader):
         self.__check_dataset_validity__()
 
     def create_dataset_mode(self):
-        self.logger.info("Mode Dataset")
+        logger.info("Mode Dataset")
         n_total = self.n_test_instances + self.n_train_instances
         self.X = np.empty((n_total, self.n_objects, self.n_features))
         self.Y = np.zeros((n_total, self.n_objects), dtype=int)
@@ -61,7 +65,7 @@ class MNISTChoiceDatasetReader(MNISTDatasetReader):
         self.__check_dataset_validity__()
 
     def create_dataset_unique(self):
-        self.logger.info("Unique Dataset")
+        logger.info("Unique Dataset")
         n_total = self.n_test_instances + self.n_train_instances
         self.X = np.empty((n_total, self.n_objects, self.n_features))
         self.Y = np.zeros((n_total, self.n_objects), dtype=int)

--- a/csrank/dataset_reader/dataset_reader.py
+++ b/csrank/dataset_reader/dataset_reader.py
@@ -18,6 +18,8 @@ from csrank.constants import EXCEPTION_UNWANTED_CONTEXT_FEATURES
 from csrank.constants import LABEL_RANKING
 from csrank.constants import OBJECT_RANKING
 
+logger = logging.getLogger(__name__)
+
 
 class DatasetReader(metaclass=ABCMeta):
     def __init__(self, dataset_folder="", learning_problem=OBJECT_RANKING, **kwargs):
@@ -38,8 +40,7 @@ class DatasetReader(metaclass=ABCMeta):
             kwargs:
                 Keyword arguments for the dataset parser
         """
-        self.dr_logger = logging.getLogger("DatasetReader")
-        self.dr_logger.info("Learning Problem: {}".format(learning_problem))
+        logger.info("Learning Problem: {}".format(learning_problem))
         self.X = None
         self.Y = None
         self.Xc = None
@@ -50,7 +51,7 @@ class DatasetReader(metaclass=ABCMeta):
         if dataset_folder is not None:
             self.dirname = os.path.join(dirname, dataset_folder)
             if not os.path.exists(self.dirname):
-                self.dr_logger.warning(
+                logger.warning(
                     "Path given for dataset does not exit {}".format(self.dirname)
                 )
         else:

--- a/csrank/dataset_reader/discretechoice/discrete_choice_data_generator.py
+++ b/csrank/dataset_reader/discretechoice/discrete_choice_data_generator.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 from scipy.spatial.distance import pdist
 from scipy.spatial.distance import squareform
@@ -18,6 +20,8 @@ except ImportError:
 
     raise MissingExtraError("pygmo", "data")
 
+logger = logging.getLogger(__name__)
+
 
 class DiscreteChoiceDatasetGenerator(SyntheticDatasetGenerator):
     def __init__(self, dataset_type="medoid", **kwargs):
@@ -36,7 +40,7 @@ class DiscreteChoiceDatasetGenerator(SyntheticDatasetGenerator):
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_function_options.keys())}"
             )
-        self.logger.info("dataset type {}".format(dataset_type))
+        logger.info("dataset type {}".format(dataset_type))
         self.dataset_function = dataset_function_options[dataset_type]
 
     def make_linear_transitive(

--- a/csrank/dataset_reader/discretechoice/expedia_discrete_choice_dataset_reader.py
+++ b/csrank/dataset_reader/discretechoice/expedia_discrete_choice_dataset_reader.py
@@ -8,13 +8,14 @@ from csrank.constants import DISCRETE_CHOICE
 from .util import sub_sampling_discrete_choices_from_relevance
 from ..expedia_dataset_reader import ExpediaDatasetReader
 
+logger = logging.getLogger(__name__)
+
 
 class ExpediaDiscreteChoiceDatasetReader(ExpediaDatasetReader):
     def __init__(self, random_state=None, n_objects=5, **kwargs):
         super(ExpediaDiscreteChoiceDatasetReader, self).__init__(
             learning_problem=DISCRETE_CHOICE, **kwargs
         )
-        self.logger = logging.getLogger(ExpediaDiscreteChoiceDatasetReader.__name__)
         self.random_state = check_random_state(random_state)
         self.n_objects = n_objects
         self.hdf5file_path = os.path.join(self.dirname, "exp_dc.h5")
@@ -44,5 +45,5 @@ class ExpediaDiscreteChoiceDatasetReader(ExpediaDatasetReader):
                 Y.append(y)
             else:
                 clicks.append(y.sum())
-        self.logger.info("Percentage of clicked {}".format(len(clicks) / len(Y)))
+        logger.info("Percentage of clicked {}".format(len(clicks) / len(Y)))
         return X, Y

--- a/csrank/dataset_reader/discretechoice/letor_listwise_discrete_choice_dataset_reader.py
+++ b/csrank/dataset_reader/discretechoice/letor_listwise_discrete_choice_dataset_reader.py
@@ -7,14 +7,13 @@ from .util import convert_to_label_encoding
 from .util import sub_sampling_discrete_choices_from_relevance
 from ..letor_listwise_dataset_reader import LetorListwiseDatasetReader
 
+logger = logging.getLogger(__name__)
+
 
 class LetorListwiseDiscreteChoiceDatasetReader(LetorListwiseDatasetReader):
     def __init__(self, random_state=None, n_objects=5, **kwargs):
         super(LetorListwiseDiscreteChoiceDatasetReader, self).__init__(
             learning_problem=DISCRETE_CHOICE, **kwargs
-        )
-        self.logger = logging.getLogger(
-            LetorListwiseDiscreteChoiceDatasetReader.__name__
         )
         self.random_state = check_random_state(random_state)
         self.n_objects = n_objects

--- a/csrank/dataset_reader/discretechoice/letor_ranking_discrete_choice_dataset_reader.py
+++ b/csrank/dataset_reader/discretechoice/letor_ranking_discrete_choice_dataset_reader.py
@@ -7,14 +7,13 @@ from csrank.dataset_reader.util import standardize_features
 from .util import sub_sampling_discrete_choices_from_relevance
 from ..letor_ranking_dataset_reader import LetorRankingDatasetReader
 
+logger = logging.getLogger(__name__)
+
 
 class LetorRankingDiscreteChoiceDatasetReader(LetorRankingDatasetReader):
     def __init__(self, random_state=None, n_objects=5, **kwargs):
         super(LetorRankingDiscreteChoiceDatasetReader, self).__init__(
             learning_problem=DISCRETE_CHOICE, **kwargs
-        )
-        self.logger = logging.getLogger(
-            LetorRankingDiscreteChoiceDatasetReader.__name__
         )
         self.random_state = check_random_state(random_state)
         self.n_objects = n_objects

--- a/csrank/dataset_reader/discretechoice/mnist_discrete_choice_dataset_reader.py
+++ b/csrank/dataset_reader/discretechoice/mnist_discrete_choice_dataset_reader.py
@@ -1,9 +1,13 @@
+import logging
+
 import numpy as np
 
 from csrank.constants import DISCRETE_CHOICE
 from .util import angle_between
 from .util import convert_to_label_encoding
 from ..mnist_dataset_reader import MNISTDatasetReader
+
+logger = logging.getLogger(__name__)
 
 
 class MNISTDiscreteChoiceDatasetReader(MNISTDatasetReader):
@@ -22,13 +26,13 @@ class MNISTDiscreteChoiceDatasetReader(MNISTDatasetReader):
         super(MNISTDiscreteChoiceDatasetReader, self).__init__(
             learning_problem=DISCRETE_CHOICE, **kwargs
         )
-        self.logger.info("Dataset type {}".format(dataset_type))
+        logger.info("Dataset type {}".format(dataset_type))
 
     def create_dataset_median(self):
-        self.logger.info("create_dataset_median")
+        logger.info("create_dataset_median")
         if self.n_objects % 2 == 0:
             self.n_objects = self.n_objects - 1
-            self.logger.info(
+            logger.info(
                 "Cannot create the dataset for even numbered sets so decreasing the set size {}".format(
                     self.n_objects
                 )
@@ -53,7 +57,7 @@ class MNISTDiscreteChoiceDatasetReader(MNISTDatasetReader):
         self.__check_dataset_validity__()
 
     def create_dataset_largest(self):
-        self.logger.info("create_dataset_largest new")
+        logger.info("create_dataset_largest new")
         n_total = self.n_test_instances + self.n_train_instances
         self.X = np.empty((n_total, self.n_objects, self.n_features))
         self.Y = np.empty(n_total, dtype=int)
@@ -73,7 +77,7 @@ class MNISTDiscreteChoiceDatasetReader(MNISTDatasetReader):
         self.__check_dataset_validity__()
 
     def create_dataset_mode_least_angle(self):
-        self.logger.info("create_dataset_maximum_occurring_number")
+        logger.info("create_dataset_maximum_occurring_number")
         n_total = self.n_test_instances + self.n_train_instances
         self.X = np.empty((n_total, self.n_objects, self.n_features))
         self.Y = np.empty(n_total, dtype=int)
@@ -99,7 +103,7 @@ class MNISTDiscreteChoiceDatasetReader(MNISTDatasetReader):
         self.__check_dataset_validity__()
 
     def create_dataset_unique(self):
-        self.logger.info("create_dataset_unique")
+        logger.info("create_dataset_unique")
         num_classes = len(np.unique(self.y_labels))
         n_total = self.n_test_instances + self.n_train_instances
         unique_number = self.random_state.randint(0, num_classes, size=n_total)

--- a/csrank/dataset_reader/discretechoice/tag_genome_discrete_choice_dataset_reader.py
+++ b/csrank/dataset_reader/discretechoice/tag_genome_discrete_choice_dataset_reader.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 from sklearn.utils import check_random_state
 
@@ -6,6 +8,8 @@ from csrank.dataset_reader.discretechoice.util import convert_to_label_encoding
 from csrank.dataset_reader.tag_genome_reader import critique_dist
 from csrank.dataset_reader.util import get_key_for_indices
 from ..tag_genome_reader import TagGenomeDatasetReader
+
+logger = logging.getLogger(__name__)
 
 
 class TagGenomeDiscreteChoiceDatasetReader(TagGenomeDatasetReader):
@@ -29,7 +33,7 @@ class TagGenomeDiscreteChoiceDatasetReader(TagGenomeDatasetReader):
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_func_dict.keys())}"
             )
-        self.logger.info("Dataset type: {}".format(dataset_type))
+        logger.info("Dataset type: {}".format(dataset_type))
         self.dataset_function = dataset_func_dict[dataset_type]
 
     def make_nearest_neighbour_dataset(self, n_instances, n_objects, seed, **kwargs):
@@ -62,7 +66,7 @@ class TagGenomeDiscreteChoiceDatasetReader(TagGenomeDatasetReader):
     def make_dissimilar_nearest_neighbour_dataset(
         self, n_instances, n_objects, seed, **kwargs
     ):
-        self.logger.info(
+        logger.info(
             "For instances {} objects {}, seed {}".format(n_instances, n_objects, seed)
         )
         X, scores = super(
@@ -77,7 +81,7 @@ class TagGenomeDiscreteChoiceDatasetReader(TagGenomeDatasetReader):
 
     def make_dissimilar_critique_dataset(self, direction):
         def dataset_generator(n_instances, n_objects, seed, **kwargs):
-            self.logger.info(
+            logger.info(
                 "For instances {} objects {}, seed {}, direction {}".format(
                     n_instances, n_objects, seed, direction
                 )

--- a/csrank/dataset_reader/labelranking/intelligent_system_group_dataset_reader.py
+++ b/csrank/dataset_reader/labelranking/intelligent_system_group_dataset_reader.py
@@ -17,6 +17,8 @@ except ImportError:
 
     raise MissingExtraError("pandas", "data")
 
+logger = logging.getLogger(__name__)
+
 
 class IntelligentSystemGroupDatasetReader(DatasetReader):
     def __init__(self, random_state=None, **kwargs):
@@ -26,7 +28,6 @@ class IntelligentSystemGroupDatasetReader(DatasetReader):
             **kwargs,
         )
 
-        self.logger = logging.getLogger(IntelligentSystemGroupDatasetReader.__name__)
         self.train_files = glob.glob(os.path.join(self.dirname, "*.txt"))
         self.train_files.sort()
         self.train_files_names = []
@@ -49,7 +50,7 @@ class IntelligentSystemGroupDatasetReader(DatasetReader):
             self.train_files_names.append(name)
             self.X[name] = features.as_matrix()
             self.Y[name] = labels.as_matrix()
-        self.logger.info("Dataset files: " + repr(self.train_files_names))
+        logger.info("Dataset files: " + repr(self.train_files_names))
 
     def get_single_train_test_split(self, name="cold"):
         cv_iter = ShuffleSplit(

--- a/csrank/dataset_reader/letor_ranking_dataset_reader.py
+++ b/csrank/dataset_reader/letor_ranking_dataset_reader.py
@@ -18,6 +18,8 @@ except ImportError:
 
     raise MissingExtraError("h5py", "data")
 
+logger = logging.getLogger(__name__)
+
 
 class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
     def __init__(self, year=2007, fold_id=0, exclude_qf=False, **kwargs):
@@ -26,7 +28,6 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
         )
         self.DATASET_FOLDER_2007 = "MQ{}".format(year)
         self.DATASET_FOLDER_2008 = "MQ{}".format(year)
-        self.logger = logging.getLogger(LetorRankingDatasetReader.__name__)
 
         if year not in [2007, 2008]:
             raise ValueError("year must be either 2007 or 2008")
@@ -36,7 +37,7 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
         self.query_document_feature_indices = np.delete(
             np.arange(0, 46), self.query_feature_indices
         )
-        self.logger.info(
+        logger.info(
             "For Year {} excluding query features {}".format(self.year, self.exclude_qf)
         )
 
@@ -49,18 +50,18 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
             h5py_file_pth = self.file_format.format(i + 1)
             self.condition[i] = os.path.isfile(h5py_file_pth)
             if not os.path.isfile(h5py_file_pth):
-                self.logger.info("File {} not created".format(h5py_file_pth))
+                logger.info("File {} not created".format(h5py_file_pth))
         assert (
             fold_id in self.dataset_indices
         ), "For fold {} no test dataset present".format(fold_id + 1)
-        self.logger.info("Test dataset is S{}".format(fold_id + 1))
+        logger.info("Test dataset is S{}".format(fold_id + 1))
         self.fold_id = fold_id
 
     def __load_dataset__(self):
         if not (self.condition.all()):
-            self.logger.info("HDF5 datasets not created.....")
-            self.logger.info("Query features {}".format(self.query_feature_indices))
-            self.logger.info(
+            logger.info("HDF5 datasets not created.....")
+            logger.info("Query features {}".format(self.query_feature_indices))
+            logger.info(
                 "Query Document features {}".format(self.query_document_feature_indices)
             )
             if self.year == "2007":
@@ -89,14 +90,14 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
                 self.merge_to_train(X, Y)
             else:
                 self.X_test, self.Y_test = self.get_choices_dict(h5py_file_path)
-        self.logger.info("Done loading the dataset")
+        logger.info("Done loading the dataset")
 
     def create_choices_dataset(self, dataset, hdf5file_path):
-        self.logger.info("Writing in hd5 {}".format(hdf5file_path))
+        logger.info("Writing in hd5 {}".format(hdf5file_path))
         X, scores = self.create_instances(dataset)
         result, freq = self._build_training_buckets(X, scores)
         h5f = h5py.File(hdf5file_path, "w")
-        self.logger.info("Frequencies of rankings: {}".format(print_dictionary(freq)))
+        logger.info("Frequencies of rankings: {}".format(print_dictionary(freq)))
 
         for key, value in result.items():
             x, s = value
@@ -158,9 +159,7 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
                     else:
                         X = np.concatenate([X, x], axis=0)
                         Y = np.concatenate([Y, y], axis=0)
-        self.logger.info(
-            "Sampled instances {} objects {}".format(X.shape[0], X.shape[1])
-        )
+        logger.info("Sampled instances {} objects {}".format(X.shape[0], X.shape[1]))
         return X, Y
 
     def create_instances(self, dataset):
@@ -200,12 +199,12 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
         return result, frequencies
 
     def create_dataset_dictionary(self, files):
-        self.logger.info("Files {}".format(files))
+        logger.info("Files {}".format(files))
         dataset_dictionaries = dict()
         for file in files:
             dataset = dict()
             key = os.path.basename(file).split(".txt")[0]
-            self.logger.info("File name {}".format(key))
+            logger.info("File name {}".format(key))
             for line in open(file):
                 information = line.split("#")[0].split(" qid:")
                 rel_deg = int(information[0])
@@ -220,7 +219,7 @@ class LetorRankingDatasetReader(DatasetReader, metaclass=ABCMeta):
                     dataset[qid].append(x)
             array = np.array([len(i) for i in dataset.values()])
             dataset_dictionaries[key] = dataset
-            self.logger.info("Maximum length of ranking: {}".format(np.max(array)))
+            logger.info("Maximum length of ranking: {}".format(np.max(array)))
         return dataset_dictionaries
 
     def sub_sampling_function(self, Xt, Yt):

--- a/csrank/dataset_reader/mnist_dataset_reader.py
+++ b/csrank/dataset_reader/mnist_dataset_reader.py
@@ -8,6 +8,8 @@ from sklearn.utils import check_random_state
 from csrank.dataset_reader.dataset_reader import DatasetReader
 from csrank.dataset_reader.util import standardize_features
 
+logger = logging.getLogger(__name__)
+
 
 class MNISTDatasetReader(DatasetReader):
     def __init__(
@@ -20,7 +22,6 @@ class MNISTDatasetReader(DatasetReader):
         **kwargs,
     ):
         super(MNISTDatasetReader, self).__init__(dataset_folder="mnist", **kwargs)
-        self.logger = logging.getLogger(MNISTDatasetReader.__name__)
         self.n_test_instances = n_test_instances
         self.n_train_instances = n_train_instances
         self.n_objects = n_objects
@@ -28,7 +29,7 @@ class MNISTDatasetReader(DatasetReader):
         self.n_features = None
         self.standardize = standardize
         self.__load_dataset__()
-        self.logger.info("Done loading the dataset")
+        logger.info("Done loading the dataset")
 
     def __load_dataset__(self):
         x_file = os.path.join(self.dirname, "X_raw_features.npy")
@@ -47,7 +48,7 @@ class MNISTDatasetReader(DatasetReader):
         )
         if self.standardize:
             x_train, x_test = standardize_features(x_train, x_test)
-        self.logger.info("Done")
+        logger.info("Done")
         return x_train, y_train, x_test, y_test
 
     def splitter(self, iter):
@@ -75,7 +76,7 @@ class MNISTDatasetReader(DatasetReader):
                 y_1,
                 y_2,
             )
-        self.logger.info("Done")
+        logger.info("Done")
         return x_train, y_train, x_test, y_test
 
     def get_train_test_datasets(self, n_datasets=5):

--- a/csrank/dataset_reader/objectranking/image_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/image_dataset_reader.py
@@ -30,6 +30,8 @@ except ImportError:
 
     raise MissingExtraError("pandas", "data")
 
+logger = logging.getLogger(__name__)
+
 
 class ImageDatasetReader(DatasetReader):
     def __init__(
@@ -50,7 +52,6 @@ class ImageDatasetReader(DatasetReader):
         # self.test_file = os.path.join(dirname, DATASET_FOLDER, "test.hd5")
         # self.labels_test_files = glob.glob(os.path.join(dirname, DATASET_FOLDER, TEST_LABEL, "*.txt"))
         # self.labels_test_files.sort()
-        self.logger = logging.getLogger(ImageDatasetReader.__name__)
 
         self.train_file = os.path.join(self.dirname, "train.hd5")
         self.similarity_matrix_train_file = os.path.join(
@@ -78,11 +79,11 @@ class ImageDatasetReader(DatasetReader):
         for file in self.labels_test_files:
             self.label_names.append(os.path.basename(file).split(".")[0].split("_")[0])
 
-        self.logger.info("Image Features Train File {}".format(self.train_file))
-        self.logger.info("Image Features Test File {}".format(self.test_file))
-        self.logger.info("Image Labels Train File {}".format(self.labels_train_files))
-        self.logger.info("Image Labels Test File {}".format(self.labels_test_files))
-        self.logger.info("Image Labels Names {}".format(self.label_names))
+        logger.info("Image Features Train File {}".format(self.train_file))
+        logger.info("Image Features Test File {}".format(self.test_file))
+        logger.info("Image Labels Train File {}".format(self.labels_train_files))
+        logger.info("Image Labels Test File {}".format(self.labels_test_files))
+        logger.info("Image Labels Names {}".format(self.label_names))
         self.random_state = check_random_state(random_state)
         if not (
             os.path.isfile(self.similarity_matrix_test_file)
@@ -213,7 +214,7 @@ class ImageDatasetReader(DatasetReader):
             ] = distance_metric_multilabel(
                 label_vectors[i], label_vectors[j], image_features[i], image_features[j]
             )
-        # self.logger.info("calculating similarity {},{},{}".format(i, j, sim))
+        # logger.info("calculating similarity {},{},{}".format(i, j, sim))
 
         for i in range(num_of_images):
             similarity_matrix_lin_list[get_key_for_indices(i, i)] = 1.0
@@ -223,7 +224,7 @@ class ImageDatasetReader(DatasetReader):
             {"col_major_index": series.index, "similarity": series.values}
         )
         matrix_df.to_csv(similarity_matrix_file)
-        self.logger.debug(
+        logger.debug(
             "Done calculating the similarity matrix stored at: {}".format(
                 similarity_matrix_file
             )

--- a/csrank/dataset_reader/objectranking/letor_listwise_object_ranking_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/letor_listwise_object_ranking_dataset_reader.py
@@ -6,14 +6,13 @@ from csrank.constants import OBJECT_RANKING
 from .util import sub_sampling_rankings
 from ..letor_listwise_dataset_reader import LetorListwiseDatasetReader
 
+logger = logging.getLogger(__name__)
+
 
 class LetorListwiseObjectRankingDatasetReader(LetorListwiseDatasetReader):
     def __init__(self, random_state=None, n_objects=5, **kwargs):
         super(LetorListwiseObjectRankingDatasetReader, self).__init__(
             learning_problem=OBJECT_RANKING, **kwargs
-        )
-        self.logger = logging.getLogger(
-            LetorListwiseObjectRankingDatasetReader.__name__
         )
         self.random_state = check_random_state(random_state)
         self.n_objects = n_objects

--- a/csrank/dataset_reader/objectranking/neural_sentence_ordering_reader.py
+++ b/csrank/dataset_reader/objectranking/neural_sentence_ordering_reader.py
@@ -14,6 +14,8 @@ except ImportError:
 
     raise MissingExtraError("h5py", "data")
 
+logger = logging.getLogger(__name__)
+
 
 class SentenceOrderingDatasetReader(DatasetReader):
     def __init__(self, n_dims=25, n_objects=5, **kwargs):
@@ -22,13 +24,12 @@ class SentenceOrderingDatasetReader(DatasetReader):
             dataset_folder="sentence_ordering",
             **kwargs,
         )
-        self.logger = logging.getLogger(name=SentenceOrderingDatasetReader.__name__)
         dimensions = {25, 50, 100, 200}
         d_files = ["test_{}_dim.h5", "train_{}_dim.h5"]
         self.n_objects = n_objects
         if n_dims not in dimensions:
             raise ValueError(f"n_dims must be one of {dimensions}")
-        self.logger.info("Loading the dataset with {} features".format(n_dims))
+        logger.info("Loading the dataset with {} features".format(n_dims))
         self.train_file = os.path.join(self.dirname, d_files[1]).format(n_dims)
         self.test_file = os.path.join(self.dirname, d_files[0]).format(n_dims)
 
@@ -39,7 +40,7 @@ class SentenceOrderingDatasetReader(DatasetReader):
         self.X_train, self.Y_train = self.get_rankings_dict(file)
         file = h5py.File(self.test_file, "r")
         self.X_test, self.Y_test = self.get_rankings_dict(file)
-        self.logger.info("Done loading the dataset")
+        logger.info("Done loading the dataset")
 
     def get_rankings_dict(self, file):
         lengths = file["lengths"]
@@ -69,9 +70,7 @@ class SentenceOrderingDatasetReader(DatasetReader):
         if self.n_objects in self.X_train:
             X = np.concatenate([X, np.copy(self.X_train[self.n_objects])], axis=0)
             Y = np.concatenate([Y, np.copy(self.Y_train[self.n_objects])], axis=0)
-        self.logger.info(
-            "Sampled instances {} objects {}".format(X.shape[0], X.shape[1])
-        )
+        logger.info("Sampled instances {} objects {}".format(X.shape[0], X.shape[1]))
         return X, Y
 
     def splitter(self, iter):

--- a/csrank/dataset_reader/objectranking/rcv_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/rcv_dataset_reader.py
@@ -10,6 +10,8 @@ from sklearn.utils import check_random_state
 from csrank.constants import OBJECT_RANKING
 from ..dataset_reader import DatasetReader
 
+logger = logging.getLogger(__name__)
+
 
 class RCVDatasetReader(DatasetReader):
     def __init__(
@@ -23,7 +25,6 @@ class RCVDatasetReader(DatasetReader):
         super(RCVDatasetReader, self).__init__(
             learning_problem=OBJECT_RANKING, dataset_folder="textual_data", **kwargs
         )
-        self.logger = logging.getLogger(name=RCVDatasetReader.__name__)
         if n_instances not in [10000]:
             raise ValueError(
                 "The number of instances should be in %s", str([100, 1000, 10000])
@@ -39,7 +40,7 @@ class RCVDatasetReader(DatasetReader):
             )
 
         self.train_file = os.path.join(self.dirname, file_name)
-        self.logger.info(self.train_file)
+        logger.info(self.train_file)
 
         self.random_state = check_random_state(random_state)
         self.__load_dataset__()

--- a/csrank/dataset_reader/objectranking/tag_genome_object_ranking_dataset_reader.py
+++ b/csrank/dataset_reader/objectranking/tag_genome_object_ranking_dataset_reader.py
@@ -1,6 +1,10 @@
+import logging
+
 from csrank.constants import OBJECT_RANKING
 from csrank.numpy_util import scores_to_rankings
 from ..tag_genome_reader import TagGenomeDatasetReader
+
+logger = logging.getLogger(__name__)
 
 
 class TagGenomeObjectRankingDatasetReader(TagGenomeDatasetReader):
@@ -17,7 +21,7 @@ class TagGenomeObjectRankingDatasetReader(TagGenomeDatasetReader):
             raise ValueError(
                 f"dataset_type must be one of {set(dataset_func_dict.keys())}"
             )
-        self.logger.info("Dataset type: {}".format(dataset_type))
+        logger.info("Dataset type: {}".format(dataset_type))
         self.dataset_function = dataset_func_dict[dataset_type]
 
     def make_nearest_neighbour_dataset(self, n_instances, n_objects, seed, **kwargs):

--- a/csrank/dataset_reader/sushi_dataset_reader.py
+++ b/csrank/dataset_reader/sushi_dataset_reader.py
@@ -72,6 +72,6 @@ class SushiDatasetReader(DatasetReader, metaclass=ABCMeta):
         self.Y = np.array(rankings)
         if self.learning_problem == DYAD_RANKING:
             self.Xc = np.array(Xc)
-            self.logger(Xc.shape)
+            self.logger.debug(Xc.shape)
         else:
             self.Xc = None

--- a/csrank/dataset_reader/sushi_dataset_reader.py
+++ b/csrank/dataset_reader/sushi_dataset_reader.py
@@ -14,6 +14,8 @@ except ImportError:
 
     raise MissingExtraError("pandas", "data")
 
+logger = logging.getLogger(__name__)
+
 
 class SushiDatasetReader(DatasetReader, metaclass=ABCMeta):
     def __init__(self, **kwargs):
@@ -24,7 +26,6 @@ class SushiDatasetReader(DatasetReader, metaclass=ABCMeta):
         self.rankings_big = os.path.join(self.dirname, "sushi_big.txt")
         self.__load_dataset__()
         self.__check_dataset_validity__()
-        self.logger = logging.getLogger(SushiDatasetReader.__name__)
 
     def __load_dataset__(self):
         # Code to concatenate the context feature to each object feature
@@ -72,6 +73,6 @@ class SushiDatasetReader(DatasetReader, metaclass=ABCMeta):
         self.Y = np.array(rankings)
         if self.learning_problem == DYAD_RANKING:
             self.Xc = np.array(Xc)
-            self.logger.debug(Xc.shape)
+            logger.debug(Xc.shape)
         else:
             self.Xc = None

--- a/csrank/dataset_reader/synthetic_dataset_generator.py
+++ b/csrank/dataset_reader/synthetic_dataset_generator.py
@@ -6,6 +6,8 @@ from sklearn.utils import check_random_state
 from csrank.dataset_reader.util import standardize_features
 from .dataset_reader import DatasetReader
 
+logger = logging.getLogger(__name__)
+
 
 class SyntheticDatasetGenerator(DatasetReader):
     def __init__(
@@ -25,9 +27,8 @@ class SyntheticDatasetGenerator(DatasetReader):
         self.kwargs = kwargs
         self.n_test_instances = n_test_instances
         self.n_train_instances = n_train_instances
-        self.logger = logging.getLogger(SyntheticDatasetGenerator.__name__)
         self.standardize = standardize
-        self.logger.info("Key word arguments {}".format(kwargs))
+        logger.info("Key word arguments {}".format(kwargs))
 
     def __load_dataset__(self):
         pass
@@ -68,7 +69,7 @@ class SyntheticDatasetGenerator(DatasetReader):
                 y_1,
                 y_2,
             )
-        self.logger.info("Done")
+        logger.info("Done")
         return x_train, y_train, x_test, y_test
 
     def get_single_train_test_split(self):
@@ -85,7 +86,7 @@ class SyntheticDatasetGenerator(DatasetReader):
         )
         if self.standardize:
             x_train, x_test = standardize_features(x_train, x_test)
-        self.logger.info("Done")
+        logger.info("Done")
 
         return x_train, y_train, x_test, y_test
 

--- a/csrank/discretechoice/baseline.py
+++ b/csrank/discretechoice/baseline.py
@@ -5,6 +5,8 @@ from sklearn.utils import check_random_state
 from csrank.learner import Learner
 from .discrete_choice import DiscreteObjectChooser
 
+logger = logging.getLogger(__name__)
+
 
 class RandomBaselineDC(DiscreteObjectChooser, Learner):
     def __init__(self, random_state=None, **kwargs):
@@ -14,7 +16,6 @@ class RandomBaselineDC(DiscreteObjectChooser, Learner):
             :param kwargs: Keyword arguments for the algorithms
         """
 
-        self.logger = logging.getLogger(RandomBaselineDC.__name__)
         self.random_state = random_state
 
     def fit(self, X, Y, **kwd):

--- a/csrank/discretechoice/cmpnet_discrete_choice.py
+++ b/csrank/discretechoice/cmpnet_discrete_choice.py
@@ -7,6 +7,8 @@ from csrank.choicefunction.util import generate_complete_pairwise_dataset
 from csrank.core.cmpnet_core import CmpNetCore
 from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 
+logger = logging.getLogger(__name__)
+
 
 class CmpNetDiscreteChoiceFunction(DiscreteObjectChooser, CmpNetCore):
     def __init__(
@@ -90,12 +92,11 @@ class CmpNetDiscreteChoiceFunction(DiscreteObjectChooser, CmpNetCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(CmpNetDiscreteChoiceFunction.__name__)
-        self.logger.info("Initializing network")
+        logger.info("Initializing network")
 
     def _convert_instances_(self, X, Y):
-        self.logger.debug("Creating the Dataset")
+        logger.debug("Creating the Dataset")
         x1, x2, garbage, y_double, garbage = generate_complete_pairwise_dataset(X, Y)
         del garbage
-        self.logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
+        logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
         return x1, x2, y_double

--- a/csrank/discretechoice/fate_discrete_choice.py
+++ b/csrank/discretechoice/fate_discrete_choice.py
@@ -7,6 +7,8 @@ from keras.regularizers import l2
 from csrank.core.fate_network import FATENetwork
 from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 
+logger = logging.getLogger(__name__)
+
 
 class FATEDiscreteChoiceFunction(DiscreteObjectChooser, FATENetwork):
     def __init__(
@@ -91,7 +93,6 @@ class FATEDiscreteChoiceFunction(DiscreteObjectChooser, FATENetwork):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FATEDiscreteChoiceFunction.__name__)
 
     def _construct_layers(self, **kwargs):
         """
@@ -106,7 +107,7 @@ class FATEDiscreteChoiceFunction(DiscreteObjectChooser, FATENetwork):
             **kwargs
                 Keyword arguments passed into the joint layers
         """
-        self.logger.info(
+        logger.info(
             "Construct joint layers hidden units {} and layers {} ".format(
                 self.n_hidden_joint_units, self.n_hidden_joint_layers
             )
@@ -120,7 +121,7 @@ class FATEDiscreteChoiceFunction(DiscreteObjectChooser, FATENetwork):
                 )
             )
 
-        self.logger.info("Construct output score node")
+        logger.info("Construct output score node")
         self.scorer = Dense(
             1,
             name="output_node",

--- a/csrank/discretechoice/fatelinear_discrete_choice.py
+++ b/csrank/discretechoice/fatelinear_discrete_choice.py
@@ -5,6 +5,8 @@ from keras.losses import categorical_hinge
 from csrank.core.fate_linear import FATELinearCore
 from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 
+logger = logging.getLogger(__name__)
+
 
 class FATELinearDiscreteChoiceFunction(DiscreteObjectChooser, FATELinearCore):
     def __init__(
@@ -57,4 +59,3 @@ class FATELinearDiscreteChoiceFunction(DiscreteObjectChooser, FATELinearCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FATELinearDiscreteChoiceFunction.__name__)

--- a/csrank/discretechoice/feta_discrete_choice.py
+++ b/csrank/discretechoice/feta_discrete_choice.py
@@ -18,6 +18,8 @@ from csrank.layers import NormalizedDense
 from csrank.numpy_util import sigmoid
 from .discrete_choice import DiscreteObjectChooser
 
+logger = logging.getLogger(__name__)
+
 
 class FETADiscreteChoiceFunction(DiscreteObjectChooser, FETANetwork):
     def __init__(
@@ -107,7 +109,6 @@ class FETADiscreteChoiceFunction(DiscreteObjectChooser, FETANetwork):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FETADiscreteChoiceFunction.__name__)
 
     def _construct_layers(self, **kwargs):
         self.input_layer = Input(
@@ -179,7 +180,7 @@ class FETADiscreteChoiceFunction(DiscreteObjectChooser, FETANetwork):
             return Lambda(lambda x: x[:, i])
 
         if self.add_zeroth_order_model:
-            self.logger.debug("Create 0th order model")
+            logger.debug("Create 0th order model")
             zeroth_order_outputs = []
             inputs = []
             for i in range(self.n_objects_fit_):
@@ -189,8 +190,8 @@ class FETADiscreteChoiceFunction(DiscreteObjectChooser, FETANetwork):
                     x = hidden(x)
                 zeroth_order_outputs.append(self.output_node_zeroth(x))
             zeroth_order_scores = concatenate(zeroth_order_outputs)
-            self.logger.debug("0th order model finished")
-        self.logger.debug("Create 1st order model")
+            logger.debug("0th order model finished")
+        logger.debug("Create 1st order model")
         outputs = [list() for _ in range(self.n_objects_fit_)]
         for i, j in combinations(range(self.n_objects_fit_), 2):
             if self.add_zeroth_order_model:
@@ -222,7 +223,7 @@ class FETADiscreteChoiceFunction(DiscreteObjectChooser, FETANetwork):
             Lambda(lambda s: K.mean(s, axis=1, keepdims=True))(x) for x in outputs
         ]
         scores = concatenate(scores)
-        self.logger.debug("1st order model finished")
+        logger.debug("1st order model finished")
         if self.add_zeroth_order_model:
 
             def get_score_object(i):
@@ -262,7 +263,7 @@ class FETADiscreteChoiceFunction(DiscreteObjectChooser, FETANetwork):
         if not self.add_zeroth_order_model:
             scores = Activation("sigmoid")(scores)
         model = Model(inputs=self.input_layer, outputs=scores)
-        self.logger.debug("Compiling complete model...")
+        logger.debug("Compiling complete model...")
         model.compile(
             loss=self.loss_function,
             optimizer=self.optimizer_,

--- a/csrank/discretechoice/fetalinear_discrete_choice.py
+++ b/csrank/discretechoice/fetalinear_discrete_choice.py
@@ -5,6 +5,8 @@ from keras.losses import categorical_hinge
 from csrank.core.feta_linear import FETALinearCore
 from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 
+logger = logging.getLogger(__name__)
+
 
 class FETALinearDiscreteChoiceFunction(DiscreteObjectChooser, FETALinearCore):
     def __init__(
@@ -55,4 +57,3 @@ class FETALinearDiscreteChoiceFunction(DiscreteObjectChooser, FETALinearCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FETALinearDiscreteChoiceFunction.__name__)

--- a/csrank/discretechoice/generalized_nested_logit.py
+++ b/csrank/discretechoice/generalized_nested_logit.py
@@ -30,6 +30,8 @@ except ImportError:
 
     raise MissingExtraError("theano", "probabilistic")
 
+logger = logging.getLogger(__name__)
+
 
 class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
     def __init__(
@@ -88,7 +90,6 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
                 [3] Chieh-Hua Wen and Frank S Koppelman. „The generalized nested logit model“. In: Transportation Research Part B: Methodological 35.7 (2001), pp. 627–641
 
         """
-        self.logger = logging.getLogger(GeneralizedNestedLogitModel.__name__)
 
         self.n_nests = n_nests
         self.alpha = alpha
@@ -162,7 +163,7 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
                     },
                 ],
             }
-            self.logger.info(
+            logger.info(
                 "Creating model with config {}".format(print_dictionary(self._config))
             )
         return self._config
@@ -262,9 +263,7 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
             indices = self.random_state_.choice(X.shape[0], upper_bound, replace=False)
             X = X[indices, :, :]
             Y = Y[indices, :]
-        self.logger.info(
-            "Train Set instances {} objects {} features {}".format(*X.shape)
-        )
+        logger.info("Train Set instances {} objects {} features {}".format(*X.shape))
         with pm.Model() as self.model:
             self.Xt = theano.shared(X)
             self.Yt = theano.shared(Y)
@@ -282,7 +281,7 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
             LogLikelihood(
                 "yl", loss_func=self.loss_function_, p=self.p, observed=self.Yt
             )
-        self.logger.info("Model construction completed")
+        logger.info("Model construction completed")
 
     def fit(
         self,

--- a/csrank/discretechoice/likelihoods.py
+++ b/csrank/discretechoice/likelihoods.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 from csrank.theano_util import normalize
 
@@ -19,6 +20,7 @@ except ImportError:
     from csrank.util import MissingExtraError
 
     raise MissingExtraError("theano", "probabilistic")
+logger = logging.getLogger(__name__)
 
 
 def categorical_crossentropy(p, y_true):
@@ -124,11 +126,11 @@ def fit_pymc3_model(self, sampler, draws, tune, vi_params, **kwargs):
                     message = e.message
                 else:
                     message = e
-                self.logger.error(message)
+                logger.error(message)
                 self.trace_vi = None
         if self.trace_vi is None and self.trace is None:
             with self.model:
-                self.logger.info(
+                logger.info(
                     "Error in vi ADVI sampler using Metropolis sampler with draws {}".format(
                         draws
                     )

--- a/csrank/discretechoice/mixed_logit_model.py
+++ b/csrank/discretechoice/mixed_logit_model.py
@@ -29,6 +29,8 @@ except ImportError:
 
     raise MissingExtraError("theano", "probabilistic")
 
+logger = logging.getLogger(__name__)
+
 
 class MixedLogitModel(DiscreteObjectChooser, Learner):
     def __init__(self, n_mixtures=4, loss_function="", regularization="l2", **kwargs):
@@ -71,7 +73,6 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
 
                 [3] Daniel McFadden and Kenneth Train. „Mixed MNL models for discrete response“. In: Journal of applied Econometrics 15.5 (2000), pp. 447–470
         """
-        self.logger = logging.getLogger(MixedLogitModel.__name__)
         self.loss_function = loss_function
         known_regularization_functions = {"l1", "l2"}
         if regularization not in known_regularization_functions:
@@ -126,7 +127,7 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
                     },
                 ]
             }
-            self.logger.info(
+            logger.info(
                 "Creating model with config {}".format(print_dictionary(self._config))
             )
         return self._config
@@ -165,7 +166,7 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
             LogLikelihood(
                 "yl", loss_func=self.loss_function_, p=self.p, observed=self.Yt
             )
-        self.logger.info("Model construction completed")
+        logger.info("Model construction completed")
 
     def fit(
         self,

--- a/csrank/discretechoice/multinomial_logit_model.py
+++ b/csrank/discretechoice/multinomial_logit_model.py
@@ -27,6 +27,8 @@ except ImportError:
 
     raise MissingExtraError("theano", "probabilistic")
 
+logger = logging.getLogger(__name__)
+
 
 class MultinomialLogitModel(DiscreteObjectChooser, Learner):
     def __init__(self, loss_function="", regularization="l2", **kwargs):
@@ -63,7 +65,6 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
 
                 [2] Kenneth Train. Qualitative choice analysis. Cambridge, MA: MIT Press, 1986
         """
-        self.logger = logging.getLogger(MultinomialLogitModel.__name__)
         self.loss_function = loss_function
         known_regularization_functions = {"l1", "l2"}
         if regularization not in known_regularization_functions:
@@ -117,7 +118,7 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
                     },
                 ]
             }
-            self.logger.info(
+            logger.info(
                 "Creating model with config {}".format(print_dictionary(self._config))
             )
         return self._config
@@ -145,7 +146,7 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
             -------
              model : pymc3 Model :class:`pm.Model`
         """
-        self.logger.info(
+        logger.info(
             "Creating model_args config {}".format(
                 print_dictionary(self.model_configuration)
             )
@@ -164,7 +165,7 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
             LogLikelihood(
                 "yl", loss_func=self.loss_function_, p=self.p, observed=self.Yt
             )
-        self.logger.info("Model construction completed")
+        logger.info("Model construction completed")
 
     def fit(
         self,

--- a/csrank/discretechoice/nested_logit_model.py
+++ b/csrank/discretechoice/nested_logit_model.py
@@ -30,6 +30,8 @@ except ImportError:
 
     raise MissingExtraError("theano", "probabilistic")
 
+logger = logging.getLogger(__name__)
+
 
 class NestedLogitModel(DiscreteObjectChooser, Learner):
     def __init__(
@@ -87,7 +89,6 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
 
                 [3] Kenneth Train and Daniel McFadden. „The goods/leisure tradeoff and disaggregate work trip mode choice models“. In: Transportation research 12.5 (1978), pp. 349–353
         """
-        self.logger = logging.getLogger(NestedLogitModel.__name__)
         self.n_nests = n_nests
         self.alpha = alpha
         self.random_state = random_state
@@ -162,7 +163,7 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
                     },
                 ],
             }
-            self.logger.info(
+            logger.info(
                 "Creating model with config {}".format(print_dictionary(self._config))
             )
         return self._config
@@ -318,9 +319,7 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
             indices = self.random_state_.choice(X.shape[0], upper_bound, replace=False)
             X = X[indices, :, :]
             Y = Y[indices, :]
-        self.logger.info(
-            "Train Set instances {} objects {} features {}".format(*X.shape)
-        )
+        logger.info("Train Set instances {} objects {} features {}".format(*X.shape))
         y_nests = self.create_nests(X)
         with pm.Model() as self.model:
             self.Xt = theano.shared(X)
@@ -341,7 +340,7 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
             LogLikelihood(
                 "yl", loss_func=self.loss_function_, p=self.p, observed=self.Yt
             )
-        self.logger.info("Model construction completed")
+        logger.info("Model construction completed")
 
     def fit(
         self,

--- a/csrank/discretechoice/paired_combinatorial_logit.py
+++ b/csrank/discretechoice/paired_combinatorial_logit.py
@@ -30,6 +30,8 @@ except ImportError:
 
     raise MissingExtraError("theano", "probabilistic")
 
+logger = logging.getLogger(__name__)
+
 
 class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
     def __init__(
@@ -88,7 +90,6 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
 
                 [3] Chaushie Chu. „A paired combinatorial logit model for travel demand analysis“. In: Proceedings of the fifth world conference on transportation research. Vol. 4.1989, pp. 295–309
         """
-        self.logger = logging.getLogger(PairedCombinatorialLogit.__name__)
         self.alpha = alpha
         self.random_state = random_state
         self.loss_function = loss_function
@@ -149,7 +150,7 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
                     },
                 ]
             }
-            self.logger.info(
+            logger.info(
                 "Creating model with config {}".format(print_dictionary(self._config))
             )
         return self._config
@@ -271,7 +272,7 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
             LogLikelihood(
                 "yl", loss_func=self.loss_function_, p=self.p, observed=self.Yt
             )
-        self.logger.info("Model construction completed")
+        logger.info("Model construction completed")
 
     def fit(
         self,

--- a/csrank/discretechoice/pairwise_discrete_choice.py
+++ b/csrank/discretechoice/pairwise_discrete_choice.py
@@ -4,6 +4,8 @@ from csrank.choicefunction.util import generate_complete_pairwise_dataset
 from csrank.core.pairwise_svm import PairwiseSVM
 from csrank.discretechoice.discrete_choice import DiscreteObjectChooser
 
+logger = logging.getLogger(__name__)
+
 
 class PairwiseSVMDiscreteChoiceFunction(DiscreteObjectChooser, PairwiseSVM):
     def __init__(
@@ -55,11 +57,10 @@ class PairwiseSVMDiscreteChoiceFunction(DiscreteObjectChooser, PairwiseSVM):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(PairwiseSVMDiscreteChoiceFunction.__name__)
-        self.logger.info("Initializing network")
+        logger.info("Initializing network")
 
     def _convert_instances_(self, X, Y):
-        self.logger.debug("Creating the Dataset")
+        logger.debug("Creating the Dataset")
         (
             garbage,
             garbage,
@@ -69,9 +70,7 @@ class PairwiseSVMDiscreteChoiceFunction(DiscreteObjectChooser, PairwiseSVM):
         ) = generate_complete_pairwise_dataset(X, Y)
         del garbage
         assert x_train.shape[1] == self.n_object_features_fit_
-        self.logger.debug(
-            "Finished the Dataset with instances {}".format(x_train.shape[0])
-        )
+        logger.debug("Finished the Dataset with instances {}".format(x_train.shape[0]))
         return x_train, y_single
 
     def fit(self, X, Y, **kwd):

--- a/csrank/discretechoice/ranknet_discrete_choice.py
+++ b/csrank/discretechoice/ranknet_discrete_choice.py
@@ -7,6 +7,8 @@ from csrank.choicefunction.util import generate_complete_pairwise_dataset
 from csrank.core.ranknet_core import RankNetCore
 from .discrete_choice import DiscreteObjectChooser
 
+logger = logging.getLogger(__name__)
+
 
 class RankNetDiscreteChoiceFunction(DiscreteObjectChooser, RankNetCore):
     def __init__(
@@ -86,12 +88,11 @@ class RankNetDiscreteChoiceFunction(DiscreteObjectChooser, RankNetCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(RankNetDiscreteChoiceFunction.__name__)
-        self.logger.info("Initializing network")
+        logger.info("Initializing network")
 
     def _convert_instances_(self, X, Y):
-        self.logger.debug("Creating the Dataset")
+        logger.debug("Creating the Dataset")
         x1, x2, garbage, garbage, y_single = generate_complete_pairwise_dataset(X, Y)
         del garbage
-        self.logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
+        logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
         return x1, x2, y_single

--- a/csrank/layers.py
+++ b/csrank/layers.py
@@ -9,6 +9,7 @@ from keras.layers.merge import average
 from keras.models import Model
 
 __all__ = ["NormalizedDense", "DeepSet", "create_input_lambda"]
+logger = logging.getLogger(__name__)
 
 
 class NormalizedDense(object):
@@ -88,10 +89,9 @@ class DeepSet(object):
         input_shape=None,
         **kwargs,
     ):
-        self.logger = logging.getLogger("DeepSets")
         self.n_units = units
         if input_shape is not None:
-            self.logger.warning(
+            logger.warning(
                 "input_shape is deprecated, since the number "
                 "of objects is now inferred"
             )
@@ -121,7 +121,7 @@ class DeepSet(object):
         n_objects, n_features = shape[1].value, shape[2].value
         if hasattr(self, "n_features"):
             if self.n_features != n_features:
-                self.logger.error("Number of features is not consistent.")
+                logger.error("Number of features is not consistent.")
         input_layer = Input(shape=(n_objects, n_features))
         inputs = [create_input_lambda(i)(input_layer) for i in range(n_objects)]
 

--- a/csrank/learner.py
+++ b/csrank/learner.py
@@ -1,7 +1,10 @@
 from abc import ABCMeta
 from abc import abstractmethod
+import logging
 
 from sklearn.base import BaseEstimator
+
+logger = logging.getLogger(__name__)
 
 
 def filter_dict_by_prefix(source, prefix):
@@ -32,9 +35,7 @@ class Learner(BaseEstimator, metaclass=ABCMeta):
             self.kernel_regularizer_ = self.kernel_regularizer(**regularizer_params)
         else:
             # No regularizer is an option.
-            self.logger.warning(
-                "You specified regularizer parameters but no regularizer."
-            )
+            logger.warning("You specified regularizer parameters but no regularizer.")
             self.kernel_regularizer_ = None
 
     @abstractmethod
@@ -88,7 +89,7 @@ class Learner(BaseEstimator, metaclass=ABCMeta):
                 Dictionary with a mapping from query set size to numpy arrays or a single numpy array of size:
                 (n_instances, n_objects)
         """
-        self.logger.info("Predicting scores")
+        logger.info("Predicting scores")
 
         if isinstance(X, dict):
             scores = dict()
@@ -119,10 +120,10 @@ class Learner(BaseEstimator, metaclass=ABCMeta):
                 predicted preferences of size:
                 (n_instances, n_objects)
         """
-        self.logger.debug("Predicting started")
+        logger.debug("Predicting started")
 
         scores = self.predict_scores(X, **kwargs)
-        self.logger.debug("Predicting scores complete")
+        logger.debug("Predicting scores complete")
 
         return self.predict_for_scores(scores, **kwargs)
 

--- a/csrank/objectranking/baseline.py
+++ b/csrank/objectranking/baseline.py
@@ -5,6 +5,8 @@ from sklearn.utils import check_random_state
 from csrank.learner import Learner
 from .object_ranker import ObjectRanker
 
+logger = logging.getLogger(__name__)
+
 
 class RandomBaselineRanker(ObjectRanker, Learner):
     def __init__(self, random_state=None, **kwargs):
@@ -14,7 +16,6 @@ class RandomBaselineRanker(ObjectRanker, Learner):
             :param kwargs: Keyword arguments for the algorithms
         """
 
-        self.logger = logging.getLogger(RandomBaselineRanker.__name__)
         self.random_state = (random_state,)
 
     def fit(self, X, Y, **kwd):

--- a/csrank/objectranking/cmp_net.py
+++ b/csrank/objectranking/cmp_net.py
@@ -8,6 +8,7 @@ from csrank.dataset_reader.objectranking.util import generate_complete_pairwise_
 from csrank.objectranking.object_ranker import ObjectRanker
 
 __all__ = ["CmpNet"]
+logger = logging.getLogger(__name__)
 
 
 class CmpNet(ObjectRanker, CmpNetCore):
@@ -97,12 +98,11 @@ class CmpNet(ObjectRanker, CmpNetCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(CmpNet.__name__)
-        self.logger.info("Initializing network")
+        logger.info("Initializing network")
 
     def _convert_instances_(self, X, Y):
-        self.logger.debug("Creating the Dataset")
+        logger.debug("Creating the Dataset")
         garbage, x1, x2, y_double, garbage = generate_complete_pairwise_dataset(X, Y)
         del garbage
-        self.logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
+        logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
         return x1, x2, y_double

--- a/csrank/objectranking/fate_object_ranker.py
+++ b/csrank/objectranking/fate_object_ranker.py
@@ -8,6 +8,8 @@ from csrank.losses import hinged_rank_loss
 from csrank.metrics import zero_one_rank_loss_for_scores_ties
 from csrank.objectranking.object_ranker import ObjectRanker
 
+logger = logging.getLogger(__name__)
+
 
 class FATEObjectRanker(ObjectRanker, FATENetwork):
     def __init__(
@@ -91,4 +93,3 @@ class FATEObjectRanker(ObjectRanker, FATENetwork):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FATEObjectRanker.__name__)

--- a/csrank/objectranking/fatelinear_object_ranker.py
+++ b/csrank/objectranking/fatelinear_object_ranker.py
@@ -4,6 +4,8 @@ from csrank.core.fate_linear import FATELinearCore
 from csrank.losses import hinged_rank_loss
 from .object_ranker import ObjectRanker
 
+logger = logging.getLogger(__name__)
+
 
 class FATELinearObjectRanker(ObjectRanker, FATELinearCore):
     def __init__(
@@ -56,4 +58,3 @@ class FATELinearObjectRanker(ObjectRanker, FATELinearCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FATELinearObjectRanker.__name__)

--- a/csrank/objectranking/feta_object_ranker.py
+++ b/csrank/objectranking/feta_object_ranker.py
@@ -8,6 +8,7 @@ from csrank.losses import hinged_rank_loss
 from .object_ranker import ObjectRanker
 
 __all__ = ["FETAObjectRanker"]
+logger = logging.getLogger(__name__)
 
 
 class FETAObjectRanker(ObjectRanker, FETANetwork):
@@ -97,4 +98,3 @@ class FETAObjectRanker(ObjectRanker, FETANetwork):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FETAObjectRanker.__name__)

--- a/csrank/objectranking/fetalinear_object_ranker.py
+++ b/csrank/objectranking/fetalinear_object_ranker.py
@@ -4,6 +4,8 @@ from csrank.core.feta_linear import FETALinearCore
 from csrank.losses import hinged_rank_loss
 from .object_ranker import ObjectRanker
 
+logger = logging.getLogger(__name__)
+
 
 class FETALinearObjectRanker(ObjectRanker, FETALinearCore):
     def __init__(
@@ -54,4 +56,3 @@ class FETALinearObjectRanker(ObjectRanker, FETALinearCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(FETALinearObjectRanker.__name__)

--- a/csrank/objectranking/list_net.py
+++ b/csrank/objectranking/list_net.py
@@ -17,6 +17,7 @@ from csrank.metrics import zero_one_rank_loss_for_scores_ties
 from csrank.objectranking.object_ranker import ObjectRanker
 
 __all__ = ["ListNet"]
+logger = logging.getLogger(__name__)
 
 
 class ListNet(ObjectRanker, Learner):
@@ -84,7 +85,6 @@ class ListNet(ObjectRanker, Learner):
             ----------
                 [1] Z. Cao, T. Qin, T. Liu, M. Tsai and H. Li. "Learning to Rank: From Pairwise Approach to Listwise Approach." ICML, 2007.
         """
-        self.logger = logging.getLogger(ListNet.__name__)
         self.n_top = n_top
         self.batch_normalization = batch_normalization
         self.activation = activation
@@ -172,13 +172,13 @@ class ListNet(ObjectRanker, Learner):
             activation=self.activation,
             **self.kwargs,
         )
-        self.logger.debug("Creating top-k dataset")
+        logger.debug("Creating top-k dataset")
         X, Y = self._create_topk(X, Y)
-        self.logger.debug("Finished creating the dataset")
+        logger.debug("Finished creating the dataset")
 
-        self.logger.debug("Creating the model")
+        logger.debug("Creating the model")
         self.model_ = self.construct_model()
-        self.logger.debug("Finished creating the model, now fitting...")
+        logger.debug("Finished creating the model, now fitting...")
         self.model_.fit(
             X,
             Y,
@@ -189,7 +189,7 @@ class ListNet(ObjectRanker, Learner):
             verbose=verbose,
             **kwd,
         )
-        self.logger.debug("Fitting Complete")
+        logger.debug("Fitting Complete")
 
     def construct_model(self):
         """
@@ -228,7 +228,7 @@ class ListNet(ObjectRanker, Learner):
                 scoring model used to predict utility score for each object
         """
         if self._scoring_model is None:
-            self.logger.info("Creating scoring model")
+            logger.info("Creating scoring model")
             inp = Input(shape=(self.n_object_features_fit_,))
             x = inp
             for hidden_layer in self.hidden_layers:
@@ -239,9 +239,7 @@ class ListNet(ObjectRanker, Learner):
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_inst, n_obj, n_feat = X.shape
-        self.logger.info(
-            "For Test instances {} objects {} features {}".format(*X.shape)
-        )
+        logger.info("For Test instances {} objects {} features {}".format(*X.shape))
         inp = Input(shape=(n_obj, n_feat))
         lambdas = [create_input_lambda(i)(inp) for i in range(n_obj)]
         scores = concatenate([self.scoring_model(lam) for lam in lambdas])

--- a/csrank/objectranking/rank_net.py
+++ b/csrank/objectranking/rank_net.py
@@ -8,6 +8,7 @@ from csrank.dataset_reader.objectranking.util import generate_complete_pairwise_
 from csrank.objectranking.object_ranker import ObjectRanker
 
 __all__ = ["RankNet"]
+logger = logging.getLogger(__name__)
 
 
 class RankNet(ObjectRanker, RankNetCore):
@@ -88,12 +89,11 @@ class RankNet(ObjectRanker, RankNetCore):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(RankNet.__name__)
-        self.logger.info("Initializing network")
+        logger.info("Initializing network")
 
     def _convert_instances_(self, X, Y):
-        self.logger.debug("Creating the Dataset")
+        logger.debug("Creating the Dataset")
         garbage, x1, x2, garbage, y_single = generate_complete_pairwise_dataset(X, Y)
         del garbage
-        self.logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
+        logger.debug("Finished the Dataset instances {}".format(x1.shape[0]))
         return x1, x2, y_single

--- a/csrank/objectranking/rank_svm.py
+++ b/csrank/objectranking/rank_svm.py
@@ -5,6 +5,7 @@ from csrank.objectranking.object_ranker import ObjectRanker
 from ..dataset_reader.objectranking.util import generate_complete_pairwise_dataset
 
 __all__ = ["RankSVM"]
+logger = logging.getLogger(__name__)
 
 
 class RankSVM(ObjectRanker, PairwiseSVM):
@@ -54,15 +55,14 @@ class RankSVM(ObjectRanker, PairwiseSVM):
             random_state=random_state,
             **kwargs,
         )
-        self.logger = logging.getLogger(RankSVM.__name__)
-        self.logger.info("Initializing network")
+        logger.info("Initializing network")
 
     def fit(self, X, Y, **kwargs):
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         super().fit(X, Y, **kwargs)
 
     def _convert_instances_(self, X, Y):
-        self.logger.debug("Creating the Dataset")
+        logger.debug("Creating the Dataset")
         (
             x_train,
             garbage,
@@ -72,7 +72,5 @@ class RankSVM(ObjectRanker, PairwiseSVM):
         ) = generate_complete_pairwise_dataset(X, Y)
         del garbage
         assert x_train.shape[1] == self.n_object_features_fit_
-        self.logger.debug(
-            "Finished the Dataset with instances {}".format(x_train.shape[0])
-        )
+        logger.debug("Finished the Dataset with instances {}".format(x_train.shape[0]))
         return x_train, y_single


### PR DESCRIPTION
## Description

This is what is usually recommended in python logging tutorials
(including the official documentation). It also frees us up from having
the "logging" attribute in our estimators, which the scikit-learn check
doesn't like (although it doesn't really hurt in this case, since a
logger hardly counts as state).

## Motivation and Context

Following standard practices and making progress on the "no_attributes_set_in_init" check of the scikit-learn estimator check suite.

## How Has This Been Tested?

Testsuite and pre-commit.

## Does this close/impact existing issues?

Impacts #94, #116.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
