### PR TITLE
Do not store kwargs

### DIFF
--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -72,14 +72,19 @@ class CmpNetChoiceFunction(ChoiceFunctions, CmpNetCore):
                 Batch size to use during training
             random_state : int, RandomState instance or None
                 Seed of the pseudorandom generator or a RandomState instance
-            **kwargs
-                Keyword arguments for the algorithms
+            hidden_dense_layer__{kwarg}
+                Arguments to be passed to the Dense layers (or NormalizedDense
+                if batch_normalization is enabled). See the keras documentation
+                for those classes for available options.
 
             References
             ----------
                 [1] Leonardo Rigutini, Tiziano Papini, Marco Maggini, and Franco Scarselli. 2011. SortNet: Learning to Rank by a Neural Preference Function. IEEE Trans. Neural Networks 22, 9 (2011), 1368–1380. https://doi.org/10.1109/TNN.2011.2160875
 
         """
+        self._store_kwargs(
+            kwargs, {"optimizer__", "kernel_regularizer__", "hidden_dense_layer__"}
+        )
         super().__init__(
             n_hidden=n_hidden,
             n_units=n_units,
@@ -92,7 +97,6 @@ class CmpNetChoiceFunction(ChoiceFunctions, CmpNetCore):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs,
         )
         logger.info("Initializing network")
         self.threshold = 0.5

--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -77,10 +77,9 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
                 List of evaluation metrics (can be non-differentiable)
             random_state : int or object
                 Numpy random state
-            **kwargs
-                Further keyword arguments for the @FATENetwork. See the
-                documentation of :func:`~csrank.core.FATENetwork.fit` for more
-                information.
+            hidden_dense_layer__{kwarg}
+                Arguments to be passed to the Dense layers. See the keras
+                documentation of ``Dense`` for available options.
         """
         self.loss_function = loss_function
         self.metrics = metrics
@@ -99,18 +98,13 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
         )
         self.threshold = 0.5
 
-    def _construct_layers(self, **kwargs):
+    def _construct_layers(self):
         """
             Construct basic layers shared by all the objects:
                 * Joint dense hidden layers
                 * Output scoring layer is sigmoid output for choice model
 
             Connecting the layers is done in join_input_layers and will be done in implementing classes.
-
-            Parameters
-            ----------
-            **kwargs
-                Keyword arguments passed into the joint layers
         """
         logger.info(
             "Construct joint layers hidden units {} and layers {} ".format(
@@ -119,10 +113,18 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
         )
         # Create joint hidden layers:
         self.joint_layers = []
+        hidden_dense_kwargs = {
+            "kernel_regularizer": self.kernel_regularizer_,
+            "kernel_initializer": self.kernel_initializer,
+            "activation": self.activation,
+        }
+        hidden_dense_kwargs.update(self._get_prefix_attributes("hidden_dense_layer__"))
         for i in range(self.n_hidden_joint_layers):
             self.joint_layers.append(
                 Dense(
-                    self.n_hidden_joint_units, name="joint_layer_{}".format(i), **kwargs
+                    self.n_hidden_joint_units,
+                    name="joint_layer_{}".format(i),
+                    **hidden_dense_kwargs,
                 )
             )
         logger.info("Construct output score node")

--- a/csrank/choicefunction/feta_choice.py
+++ b/csrank/choicefunction/feta_choice.py
@@ -91,9 +91,14 @@ class FETAChoiceFunction(ChoiceFunctions, FETANetwork):
                 Batch size to use for training
             random_state : int or object
                 Numpy random state
-            **kwargs
-                Keyword arguments for the hidden units
+            hidden_dense_layer__{kwarg}
+                Arguments to be passed to the Dense layers (or NormalizedDense
+                if batch_normalization is enabled). See the keras documentation
+                for those classes for available options.
         """
+        self._store_kwargs(
+            kwargs, {"optimizer__", "kernel_regularizer__", "hidden_dense_layer__"}
+        )
         super().__init__(
             n_hidden=n_hidden,
             n_units=n_units,
@@ -109,36 +114,49 @@ class FETAChoiceFunction(ChoiceFunctions, FETANetwork):
             metrics=metrics,
             batch_size=batch_size,
             random_state=random_state,
-            **kwargs,
         )
         self.threshold = 0.5
 
-    def _construct_layers(self, **kwargs):
+    def _construct_layers(self):
         self.input_layer = Input(
             shape=(self.n_objects_fit_, self.n_object_features_fit_)
         )
         # Todo: Variable sized input
         # X = Input(shape=(None, n_features))
+        hidden_dense_kwargs = {
+            "kernel_regularizer": self.kernel_regularizer_,
+            "kernel_initializer": self.kernel_initializer,
+            "activation": self.activation,
+        }
+        hidden_dense_kwargs.update(self._get_prefix_attributes("hidden_dense_layer__"))
         if self.batch_normalization:
             if self.add_zeroth_order_model:
                 self.hidden_layers_zeroth = [
                     NormalizedDense(
-                        self.n_units, name="hidden_zeroth_{}".format(x), *kwargs
+                        self.n_units,
+                        name="hidden_zeroth_{}".format(x),
+                        *hidden_dense_kwargs,
                     )
                     for x in range(self.n_hidden)
                 ]
             self.hidden_layers = [
-                NormalizedDense(self.n_units, name="hidden_{}".format(x), **kwargs)
+                NormalizedDense(
+                    self.n_units, name="hidden_{}".format(x), **hidden_dense_kwargs
+                )
                 for x in range(self.n_hidden)
             ]
         else:
             if self.add_zeroth_order_model:
                 self.hidden_layers_zeroth = [
-                    Dense(self.n_units, name="hidden_zeroth_{}".format(x), **kwargs)
+                    Dense(
+                        self.n_units,
+                        name="hidden_zeroth_{}".format(x),
+                        **hidden_dense_kwargs,
+                    )
                     for x in range(self.n_hidden)
                 ]
             self.hidden_layers = [
-                Dense(self.n_units, name="hidden_{}".format(x), **kwargs)
+                Dense(self.n_units, name="hidden_{}".format(x), **hidden_dense_kwargs)
                 for x in range(self.n_hidden)
             ]
         assert len(self.hidden_layers) == self.n_hidden

--- a/csrank/constants.py
+++ b/csrank/constants.py
@@ -20,25 +20,6 @@ EXCEPTION_RANKINGS_FEATURES_NO_OF_OBJECTS = (
 )
 EXCEPTION_RANKINGS = "Unwanted rankings in {} dataset"
 EXCEPTION_SET_INCLUSION = "Choice Set inclusion/exclusion binary code not present for all the objects in the set."
-allowed_dense_kwargs = [
-    "input_shape",
-    "batch_input_shape",
-    "batch_size",
-    "dtype",
-    "name",
-    "trainable",
-    "weights",
-    "input_dtype",
-    "activation",
-    "use_bias",
-    "kernel_initializer",
-    "bias_initializer",
-    "kernel_regularizer",
-    "bias_regularizer",
-    "activity_regularizer",
-    "kernel_constraint",
-    "bias_constraint",
-]
 
 RANKSVM = "ranksvm"
 

--- a/csrank/discretechoice/cmpnet_discrete_choice.py
+++ b/csrank/discretechoice/cmpnet_discrete_choice.py
@@ -71,8 +71,10 @@ class CmpNetDiscreteChoiceFunction(DiscreteObjectChooser, CmpNetCore):
                 Batch size to use during training
             random_state : int, RandomState instance or None
                 Seed of the pseudorandom generator or a RandomState instance
-            **kwargs
-                Keyword arguments for the algorithms
+            hidden_dense_layer__{kwarg}
+                Arguments to be passed to the Dense layers (or NormalizedDense
+                if batch_normalization is enabled). See the keras documentation
+                for those classes for available options.
 
             References
             ----------

--- a/csrank/objectranking/cmp_net.py
+++ b/csrank/objectranking/cmp_net.py
@@ -76,8 +76,10 @@ class CmpNet(ObjectRanker, CmpNetCore):
                Batch size to use during training
            random_state : int, RandomState instance or None
                Seed of the pseudorandom generator or a RandomState instance
-           **kwargs
-               Keyword arguments for the algorithms
+           hidden_dense_layer__{kwarg}
+               Arguments to be passed to the Dense layers (or NormalizedDense
+               if batch_normalization is enabled). See the keras documentation
+               for those classes for available options.
 
 
            References

--- a/csrank/tests/test_fate.py
+++ b/csrank/tests/test_fate.py
@@ -32,11 +32,7 @@ def test_construction_core():
     grc = MockClass()
     grc._initialize_optimizer()
     grc._initialize_regularizer()
-    grc._construct_layers(
-        activation=grc.activation,
-        kernel_initializer=grc.kernel_initializer,
-        kernel_regularizer=grc.kernel_regularizer_,
-    )
+    grc._construct_layers()
     input_layer = Input(shape=(n_objects, n_features))
     scores = grc.join_input_layers(input_layer, None, n_layers=0, n_objects=n_objects)
 


### PR DESCRIPTION
## Description

Changes are on top of #154 to avoid merge conflicts.

~**#154 should be reviewed first.**~

## Motivation and Context

The mechanism is replaced by the already established prefixing and an
explicit prefix whitelist. This is more explicit than just passing
around "raw" kwargs, easier to understand and satisfies the "no
attributes in init" check for scikit-learn estimators.

## How Has This Been Tested?

Pre-commit and test suite.

## Does this close/impact existing issues?

Related to #94, #116, #146.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
