### PR TITLE
Take care of the long tail of attributes in init

### DIFF
--- a/csrank/choicefunction/choice_functions.py
+++ b/csrank/choicefunction/choice_functions.py
@@ -41,10 +41,10 @@ class ChoiceFunctions(metaclass=ABCMeta):
         if isinstance(scores, dict):
             result = dict()
             for n, score in scores.items():
-                result[n] = score > self.threshold
+                result[n] = score > self.threshold_
                 result[n] = np.array(result[n], dtype=int)
         else:
-            result = scores > self.threshold
+            result = scores > self.threshold_
             result = np.array(result, dtype=int)
         return result
 

--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -98,8 +98,6 @@ class CmpNetChoiceFunction(ChoiceFunctions, CmpNetCore):
             batch_size=batch_size,
             random_state=random_state,
         )
-        logger.info("Initializing network")
-        self.threshold = 0.5
 
     def _convert_instances_(self, X, Y):
         logger.debug("Creating the Dataset")
@@ -174,6 +172,9 @@ class CmpNetChoiceFunction(ChoiceFunctions, CmpNetCore):
                 logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
+                self.threshold_ = self._tune_threshold(
+                    X_val, Y_val, thin_thresholds=thin_thresholds, verbose=verbose
+                )
         else:
             super().fit(X, Y, epochs, callbacks, validation_split, verbose, **kwd)
-            self.threshold = 0.5
+            self.threshold_ = 0.5

--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -96,7 +96,6 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
             random_state=random_state,
             **kwargs,
         )
-        self.threshold = 0.5
 
     def _construct_layers(self):
         """
@@ -174,9 +173,9 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
                 logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
-                self.threshold = self._tune_threshold(
+                self.threshold_ = self._tune_threshold(
                     X_val, Y_val, thin_thresholds=thin_thresholds, verbose=verbose
                 )
         else:
             super().fit(X, Y, **kwargs)
-            self.threshold = 0.5
+            self.threshold_ = 0.5

--- a/csrank/choicefunction/fatelinear_choice.py
+++ b/csrank/choicefunction/fatelinear_choice.py
@@ -91,9 +91,9 @@ class FATELinearChoiceFunction(ChoiceFunctions, FATELinearCore):
                 logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
-                self.threshold = self._tune_threshold(
+                self.threshold_ = self._tune_threshold(
                     X_val, Y_val, thin_thresholds=thin_thresholds, verbose=verbose
                 )
         else:
             super().fit(X, Y, epochs, callbacks, validation_split, verbose, **kwd)
-            self.threshold = 0.5
+            self.threshold_ = 0.5

--- a/csrank/choicefunction/feta_choice.py
+++ b/csrank/choicefunction/feta_choice.py
@@ -115,7 +115,6 @@ class FETAChoiceFunction(ChoiceFunctions, FETANetwork):
             batch_size=batch_size,
             random_state=random_state,
         )
-        self.threshold = 0.5
 
     def _construct_layers(self):
         self.input_layer = Input(
@@ -305,12 +304,12 @@ class FETAChoiceFunction(ChoiceFunctions, FETANetwork):
                 logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
-                self.threshold = self._tune_threshold(
+                self.threshold_ = self._tune_threshold(
                     X_val, Y_val, thin_thresholds=thin_thresholds, verbose=verbose
                 )
         else:
             super().fit(X, Y, epochs, callbacks, validation_split, verbose, **kwd)
-            self.threshold = 0.5
+            self.threshold_ = 0.5
 
     def sub_sampling(self, X, Y):
         if self.n_objects_fit_ <= self.max_number_of_objects:

--- a/csrank/choicefunction/fetalinear_choice.py
+++ b/csrank/choicefunction/fetalinear_choice.py
@@ -89,9 +89,9 @@ class FETALinearChoiceFunction(ChoiceFunctions, FETALinearCore):
                 logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
-                self.threshold = self._tune_threshold(
+                self.threshold_ = self._tune_threshold(
                     X_val, Y_val, thin_thresholds=thin_thresholds, verbose=verbose
                 )
         else:
             super().fit(X, Y, epochs, callbacks, validation_split, verbose, **kwd)
-            self.threshold = 0.5
+            self.threshold_ = 0.5

--- a/csrank/choicefunction/pairwise_choice.py
+++ b/csrank/choicefunction/pairwise_choice.py
@@ -60,8 +60,6 @@ class PairwiseSVMChoiceFunction(ChoiceFunctions, PairwiseSVM):
             random_state=random_state,
             **kwargs,
         )
-        logger.info("Initializing network")
-        self.threshold = 0.5
 
     def _convert_instances_(self, X, Y):
         logger.debug("Creating the Dataset")
@@ -109,9 +107,9 @@ class PairwiseSVMChoiceFunction(ChoiceFunctions, PairwiseSVM):
                 logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
-                self.threshold = self._tune_threshold(
+                self.threshold_ = self._tune_threshold(
                     X_val, Y_val, thin_thresholds=thin_thresholds, verbose=verbose
                 )
         else:
             super().fit(X, Y, **kwd)
-            self.threshold = 0.5
+            self.threshold_ = 0.5

--- a/csrank/choicefunction/ranknet_choice.py
+++ b/csrank/choicefunction/ranknet_choice.py
@@ -88,8 +88,6 @@ class RankNetChoiceFunction(ChoiceFunctions, RankNetCore):
             random_state=random_state,
             **kwargs,
         )
-        logger.info("Initializing network")
-        self.threshold = 0.5
 
     def _convert_instances_(self, X, Y):
         logger.debug("Creating the Dataset")
@@ -161,9 +159,9 @@ class RankNetChoiceFunction(ChoiceFunctions, RankNetCore):
                 logger.info(
                     "Fitting utility function finished. Start tuning threshold."
                 )
-                self.threshold = self._tune_threshold(
+                self.threshold_ = self._tune_threshold(
                     X_val, Y_val, thin_thresholds=thin_thresholds, verbose=verbose
                 )
         else:
             super().fit(X, Y, epochs, callbacks, validation_split, verbose, **kwd)
-            self.threshold = 0.5
+            self.threshold_ = 0.5

--- a/csrank/core/fate_network.py
+++ b/csrank/core/fate_network.py
@@ -70,14 +70,12 @@ class FATENetworkCore(Learner):
         self.kernel_regularizer = kernel_regularizer
         self.batch_size = batch_size
         self.optimizer = optimizer
-        self.joint_layers = None
-        self.scorer = None
         self._initialize_optimizer()
         self._initialize_regularizer()
+        self._construct_layers()
         self._store_kwargs(
             kwargs, {"optimizer__", "kernel_regularizer__", "hidden_dense_layer__"}
         )
-        self._construct_layers()
 
     def _construct_layers(self):
         """
@@ -176,7 +174,6 @@ class FATENetwork(FATENetworkCore):
             kernel_initializer=self.kernel_initializer,
             kernel_regularizer=self.kernel_regularizer_,
         )
-        self.is_variadic = True
 
     def _create_set_layers(self, **kwargs):
         """
@@ -237,7 +234,7 @@ class FATENetwork(FATENetworkCore):
         return models
 
     def get_weights(self, n_objects=None):
-        if self.is_variadic:
+        if self.is_variadic_:
             if n_objects is not None:
                 weights = self.models_[n_objects].get_weights()
             else:
@@ -247,7 +244,7 @@ class FATENetwork(FATENetworkCore):
         return weights
 
     def set_weights(self, weights, n_objects=None):
-        if self.is_variadic:
+        if self.is_variadic_:
             if n_objects is not None:
                 self.models_[n_objects].set_weights(weights)
             else:
@@ -317,7 +314,7 @@ class FATENetwork(FATENetworkCore):
             if generator is not None:
                 logger.error("Variadic training does not support generators yet.")
                 raise NotImplementedError
-            self.is_variadic = True
+            self.is_variadic_ = True
             decay_rate = global_lr / epochs
             learning_rate = global_lr
             freq = self._bucket_frequencies(X, min_bucket_size=min_bucket_size)
@@ -371,7 +368,7 @@ class FATENetwork(FATENetworkCore):
                     )
                 learning_rate /= 1 + decay_rate * epoch
         else:
-            self.is_variadic = False
+            self.is_variadic_ = False
 
             if not hasattr(self, "model_") or refit:
                 if generator is not None:

--- a/csrank/core/pairwise_svm.py
+++ b/csrank/core/pairwise_svm.py
@@ -53,7 +53,6 @@ class PairwiseSVM(Learner):
         self.use_logistic_regression = use_logistic_regression
         self.random_state = random_state
         self.fit_intercept = fit_intercept
-        self.weights = None
 
     def fit(self, X, Y, **kwargs):
         """
@@ -96,18 +95,18 @@ class PairwiseSVM(Learner):
         logger.debug("Finished Creating the model, now fitting started")
 
         self.model_.fit(x_train, y_single)
-        self.weights = self.model_.coef_.flatten()
+        self.weights_ = self.model_.coef_.flatten()
         if self.fit_intercept:
-            self.weights = np.append(self.weights, self.model_.intercept_)
+            self.weights_ = np.append(self.weights_, self.model_.intercept_)
         logger.debug("Fitting Complete")
 
     def _predict_scores_fixed(self, X, **kwargs):
         assert X.shape[-1] == self.n_object_features_fit_
         logger.info("For Test instances {} objects {} features {}".format(*X.shape))
         if self.fit_intercept:
-            scores = np.dot(X, self.weights[:-1])
+            scores = np.dot(X, self.weights_[:-1])
         else:
-            scores = np.dot(X, self.weights)
+            scores = np.dot(X, self.weights_)
         logger.info("Done predicting scores")
         return np.array(scores)
 

--- a/csrank/core/ranknet_core.py
+++ b/csrank/core/ranknet_core.py
@@ -41,7 +41,6 @@ class RankNetCore(Learner):
         self.n_hidden = n_hidden
         self.n_units = n_units
         self.batch_size = batch_size
-        self._scoring_model = None
         self.random_state = random_state
         self._store_kwargs(
             kwargs, {"optimizer__", "kernel_regularizer__", "hidden_dense_layer__"}
@@ -177,15 +176,15 @@ class RankNetCore(Learner):
              model: keras :class:`Model`
                 Neural network to learn the non-linear utility score
         """
-        if self._scoring_model is None:
+        if not hasattr(self, "scoring_model_"):
             logger.info("creating scoring model")
             inp = Input(shape=(self.n_object_features_fit_,))
             x = inp
             for hidden_layer in self.hidden_layers:
                 x = hidden_layer(x)
             output_score = self.output_node(x)
-            self._scoring_model = Model(inputs=[inp], outputs=output_score)
-        return self._scoring_model
+            self.scoring_model_ = Model(inputs=[inp], outputs=output_score)
+        return self.scoring_model_
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_instances, n_objects, n_features = X.shape

--- a/csrank/discretechoice/likelihoods.py
+++ b/csrank/discretechoice/likelihoods.py
@@ -117,18 +117,18 @@ def fit_pymc3_model(self, sampler, draws, tune, vi_params, **kwargs):
     if sampler == "variational":
         with self.model:
             try:
-                self.trace = pm.sample(chains=2, cores=8, tune=5, draws=5)
-                vi_params["start"] = self.trace[-1]
-                self.trace_vi = pm.fit(**vi_params)
-                self.trace = self.trace_vi.sample(draws=draws)
+                self.trace_ = pm.sample(chains=2, cores=8, tune=5, draws=5)
+                vi_params["start"] = self.trace_[-1]
+                self.trace_vi_ = pm.fit(**vi_params)
+                self.trace_ = self.trace_vi_.sample(draws=draws)
             except Exception as e:
                 if hasattr(e, "message"):
                     message = e.message
                 else:
                     message = e
                 logger.error(message)
-                self.trace_vi = None
-        if self.trace_vi is None and self.trace is None:
+                self.trace_vi_ = None
+        if self.trace_vi_ is None and self.trace_ is None:
             with self.model:
                 logger.info(
                     "Error in vi ADVI sampler using Metropolis sampler with draws {}".format(
@@ -141,7 +141,7 @@ def fit_pymc3_model(self, sampler, draws, tune, vi_params, **kwargs):
     elif sampler == "metropolis":
         with self.model:
             start = pm.find_MAP()
-            self.trace = pm.sample(
+            self.trace_ = pm.sample(
                 chains=2,
                 cores=8,
                 tune=tune,
@@ -152,6 +152,6 @@ def fit_pymc3_model(self, sampler, draws, tune, vi_params, **kwargs):
             )
     else:
         with self.model:
-            self.trace = pm.sample(
+            self.trace_ = pm.sample(
                 chains=2, cores=8, tune=tune, draws=draws, **kwargs, step=pm.NUTS()
             )

--- a/csrank/discretechoice/paired_combinatorial_logit.py
+++ b/csrank/discretechoice/paired_combinatorial_logit.py
@@ -99,12 +99,6 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
                 f"Regularization function {regularization} is unknown. Must be one of {known_regularization_functions}"
             )
         self.regularization = regularization
-        self._config = None
-        self.trace = None
-        self.trace_vi = None
-        self.Xt = None
-        self.Yt = None
-        self.p = None
 
     @property
     def model_configuration(self):
@@ -134,14 +128,14 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
                 configuration : dict
                     Dictionary containing the priors applies on the weights
         """
-        if self._config is None:
+        if not hasattr(self, "config_"):
             if self.regularization == "l2":
                 weight = pm.Normal
                 prior = "sd"
             elif self.regularization == "l1":
                 weight = pm.Laplace
                 prior = "b"
-            self._config = {
+            self.config_ = {
                 "weights": [
                     weight,
                     {
@@ -151,9 +145,9 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
                 ]
             }
             logger.info(
-                "Creating model with config {}".format(print_dictionary(self._config))
+                "Creating model with config {}".format(print_dictionary(self.config_))
             )
-        return self._config
+        return self.config_
 
     #
 
@@ -260,17 +254,19 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
             -------
              model : pymc3 Model :class:`pm.Model`
         """
+        self.trace_ = None
+        self.trace_vi_ = None
         self.loss_function_ = likelihood_dict.get(self.loss_function, None)
         with pm.Model() as self.model:
-            self.Xt = theano.shared(X)
-            self.Yt = theano.shared(Y)
+            self.Xt_ = theano.shared(X)
+            self.Yt_ = theano.shared(Y)
             shapes = {"weights": self.n_object_features_fit_}
             weights_dict = create_weight_dictionary(self.model_configuration, shapes)
             lambda_k = pm.Uniform("lambda_k", self.alpha, 1.0, shape=self.n_nests)
-            utility = tt.dot(self.Xt, weights_dict["weights"])
-            self.p = self.get_probabilities(utility, lambda_k)
+            utility = tt.dot(self.Xt_, weights_dict["weights"])
+            self.p_ = self.get_probabilities(utility, lambda_k)
             LogLikelihood(
-                "yl", loss_func=self.loss_function_, p=self.p, observed=self.Yt
+                "yl", loss_func=self.loss_function_, p=self.p_, observed=self.Yt_
             )
         logger.info("Model construction completed")
 
@@ -334,7 +330,7 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
         fit_pymc3_model(self, sampler, draws, tune, vi_params, **kwargs)
 
     def _predict_scores_fixed(self, X, **kwargs):
-        mean_trace = dict(pm.summary(self.trace)["mean"])
+        mean_trace = dict(pm.summary(self.trace_)["mean"])
         weights = np.array(
             [
                 mean_trace["weights[{}]".format(i)]

--- a/csrank/objectranking/expected_rank_regression.py
+++ b/csrank/objectranking/expected_rank_regression.py
@@ -71,7 +71,6 @@ class ExpectedRankRegression(ObjectRanker, Learner):
         self.tol = tol
         self.fit_intercept = fit_intercept
         self.random_state = random_state
-        self.weights = None
 
     def fit(self, X, Y, **kwargs):
         """
@@ -120,9 +119,9 @@ class ExpectedRankRegression(ObjectRanker, Learner):
                 logger.info("Ridge")
         logger.debug("Finished Creating the model, now fitting started")
         self.model_.fit(x_train, y_train)
-        self.weights = self.model_.coef_.flatten()
+        self.weights_ = self.model_.coef_.flatten()
         if self.fit_intercept:
-            self.weights = np.append(self.weights, self.model_.intercept_)
+            self.weights_ = np.append(self.weights_, self.model_.intercept_)
         logger.debug("Fitting Complete")
 
     def _predict_scores_fixed(self, X, **kwargs):

--- a/csrank/objectranking/list_net.py
+++ b/csrank/objectranking/list_net.py
@@ -103,7 +103,6 @@ class ListNet(ObjectRanker, Learner):
 
         self.batch_size = batch_size
         self.random_state = random_state
-        self._scoring_model = None
         self._store_kwargs(
             kwargs, {"hidden_dense__", "optimizer__", "kernel_regularizer__"}
         )
@@ -233,15 +232,15 @@ class ListNet(ObjectRanker, Learner):
             scoring_model: keras model :class:`Model`
                 scoring model used to predict utility score for each object
         """
-        if self._scoring_model is None:
+        if not hasattr(self, "scoring_model_"):
             logger.info("Creating scoring model")
             inp = Input(shape=(self.n_object_features_fit_,))
             x = inp
             for hidden_layer in self.hidden_layers:
                 x = hidden_layer(x)
             output_score = self.output_node(x)
-            self._scoring_model = Model(inputs=inp, outputs=output_score)
-        return self._scoring_model
+            self.scoring_model_ = Model(inputs=inp, outputs=output_score)
+        return self.scoring_model_
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_inst, n_obj, n_feat = X.shape


### PR DESCRIPTION
## Description

After removing some big sets (#154, #155), this PR is supposed to take care of the ["long tail"](https://github.com/kiudee/cs-ranking/pull/116#issuecomment-682708859) of failures of the `check_no_attributes_set_in_init` sklearn estimator check.

~This is a work in progress. Builds on #154, #155 which should be reviewed first.~

Also see the commit message:

Most of these attributes are actually initialized during fit and the
values do not need to be set in init. To conform the the scikit-learn
estimator API, we should not set them in init and postfix values that
are learned from the data with an underscore.

This takes care of most of the remaining attributes in init. The
remaining attributes are due to `construct_model` being called in
`__init__`, which cannot currently be easily fixed. A workaround for
that will follow.

## Motivation and Context

Trying to meet the scikit-learn estimator requirements.

## How Has This Been Tested?

Work in progress.

## Does this close/impact existing issues?

Related to #94, #116.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
