### PR TITLE
Move stateful initialization to a pre_fit function

### DIFF
--- a/csrank/choicefunction/baseline.py
+++ b/csrank/choicefunction/baseline.py
@@ -18,7 +18,7 @@ class AllPositive(ChoiceFunctions, Learner):
         """
 
     def fit(self, X, Y, **kwd):
-        pass
+        self._pre_fit()
 
     def _predict_scores_fixed(self, X, Y, **kwargs):
         return np.zeros_like(Y) + Y.mean()

--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -154,6 +154,7 @@ class CmpNetChoiceFunction(ChoiceFunctions, CmpNetCore):
             **kwd :
                 Keyword arguments for the fit function
         """
+        self._pre_fit()
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
                 X, Y, test_size=tune_size, random_state=self.random_state

--- a/csrank/choicefunction/fate_choice.py
+++ b/csrank/choicefunction/fate_choice.py
@@ -163,6 +163,7 @@ class FATEChoiceFunction(ChoiceFunctions, FATENetwork):
                 documentation of :func:`~csrank.core.FATENetwork.fit` for more
                 information.
         """
+        self._pre_fit()
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
                 X, Y, test_size=tune_size, random_state=self.random_state

--- a/csrank/choicefunction/fatelinear_choice.py
+++ b/csrank/choicefunction/fatelinear_choice.py
@@ -73,6 +73,7 @@ class FATELinearChoiceFunction(ChoiceFunctions, FATELinearCore):
         verbose=0,
         **kwd,
     ):
+        self._pre_fit()
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
                 X, Y, test_size=tune_size, random_state=self.random_state

--- a/csrank/choicefunction/feta_choice.py
+++ b/csrank/choicefunction/feta_choice.py
@@ -286,6 +286,7 @@ class FETAChoiceFunction(ChoiceFunctions, FETANetwork):
             **kwd :
                 Keyword arguments for the fit function
         """
+        self._pre_fit()
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
                 X, Y, test_size=tune_size, random_state=self.random_state

--- a/csrank/choicefunction/fetalinear_choice.py
+++ b/csrank/choicefunction/fetalinear_choice.py
@@ -71,6 +71,7 @@ class FETALinearChoiceFunction(ChoiceFunctions, FETALinearCore):
         verbose=0,
         **kwd,
     ):
+        self._pre_fit()
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
                 X, Y, test_size=tune_size, random_state=self.random_state

--- a/csrank/choicefunction/generalized_linear_model.py
+++ b/csrank/choicefunction/generalized_linear_model.py
@@ -158,6 +158,10 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
             BinaryCrossEntropyLikelihood("yl", p=self.p_, observed=self.Yt_)
         logger.info("Model construction completed")
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+
     def fit(
         self,
         X,
@@ -217,7 +221,7 @@ class GeneralizedLinearModel(ChoiceFunctions, Learner):
             **kwargs :
                 Keyword arguments for the fit function
         """
-        self.random_state_ = check_random_state(self.random_state)
+        self._pre_fit()
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
                 X, Y, test_size=tune_size, random_state=self.random_state_

--- a/csrank/choicefunction/pairwise_choice.py
+++ b/csrank/choicefunction/pairwise_choice.py
@@ -96,6 +96,7 @@ class PairwiseSVMChoiceFunction(ChoiceFunctions, PairwiseSVM):
                 Keyword arguments for the fit function
 
         """
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(

--- a/csrank/choicefunction/ranknet_choice.py
+++ b/csrank/choicefunction/ranknet_choice.py
@@ -141,6 +141,7 @@ class RankNetChoiceFunction(ChoiceFunctions, RankNetCore):
             **kwd :
                 Keyword arguments for the fit function
         """
+        self._pre_fit()
         if tune_size > 0:
             X_train, X_val, Y_train, Y_val = train_test_split(
                 X, Y, test_size=tune_size, random_state=self.random_state

--- a/csrank/core/cmpnet_core.py
+++ b/csrank/core/cmpnet_core.py
@@ -95,8 +95,6 @@ class CmpNetCore(Learner):
             model: keras :class:`Model`
                 Neural network to learn the CmpNet utility score
         """
-        self._initialize_optimizer()
-        self._initialize_regularizer()
         x1x2 = concatenate([self.x1, self.x2])
         x2x1 = concatenate([self.x2, self.x1])
         logger.debug("Creating the model")
@@ -115,6 +113,12 @@ class CmpNetCore(Learner):
             metrics=list(self.metrics),
         )
         return model
+
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+        self._initialize_optimizer()
+        self._initialize_regularizer()
 
     def fit(
         self, X, Y, epochs=10, callbacks=None, validation_split=0.1, verbose=0, **kwd
@@ -151,8 +155,7 @@ class CmpNetCore(Learner):
             **kwd :
                 Keyword arguments for the fit function
         """
-        self.random_state_ = check_random_state(self.random_state)
-        self._initialize_regularizer()
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         x1, x2, y_double = self._convert_instances_(X, Y)
 

--- a/csrank/core/fate_linear.py
+++ b/csrank/core/fate_linear.py
@@ -86,10 +86,14 @@ class FATELinearCore(Learner):
             self.loss_
         )
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+
     def fit(
         self, X, Y, epochs=10, callbacks=None, validation_split=0.1, verbose=0, **kwd
     ):
-        self.random_state_ = check_random_state(self.random_state)
+        self._pre_fit()
         # Global Variables Initializer
         n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         self._construct_model_(self.n_objects_fit_)

--- a/csrank/core/fate_network.py
+++ b/csrank/core/fate_network.py
@@ -70,9 +70,6 @@ class FATENetworkCore(Learner):
         self.kernel_regularizer = kernel_regularizer
         self.batch_size = batch_size
         self.optimizer = optimizer
-        self._initialize_optimizer()
-        self._initialize_regularizer()
-        self._construct_layers()
         self._store_kwargs(
             kwargs, {"optimizer__", "kernel_regularizer__", "hidden_dense_layer__"}
         )
@@ -148,6 +145,12 @@ class FATENetworkCore(Learner):
 
         return scores
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self._initialize_optimizer()
+        self._initialize_regularizer()
+        self._construct_layers()
+
 
 class FATENetwork(FATENetworkCore):
     def __init__(self, n_hidden_set_layers=1, n_hidden_set_units=1, **kwargs):
@@ -168,12 +171,6 @@ class FATENetwork(FATENetworkCore):
 
         self.n_hidden_set_layers = n_hidden_set_layers
         self.n_hidden_set_units = n_hidden_set_units
-        self.set_layer = None
-        self._create_set_layers(
-            activation=self.activation,
-            kernel_initializer=self.kernel_initializer,
-            kernel_regularizer=self.kernel_regularizer_,
-        )
 
     def _create_set_layers(self, **kwargs):
         """
@@ -186,11 +183,11 @@ class FATENetwork(FATENetworkCore):
             )
         )
         if self.n_hidden_set_layers >= 1:
-            self.set_layer = DeepSet(
+            self.set_layer_ = DeepSet(
                 units=self.n_hidden_set_units, layers=self.n_hidden_set_layers, **kwargs
             )
         else:
-            self.set_layer = None
+            self.set_layer_ = None
 
     @staticmethod
     def _bucket_frequencies(X, min_bucket_size=32):
@@ -308,6 +305,7 @@ class FATENetwork(FATENetworkCore):
             **kwargs :
                 Keyword arguments for the fit function
         """
+        self._pre_fit()
         if optimizer is not None:
             self.optimizer = optimizer
         if isinstance(X, dict):
@@ -422,7 +420,7 @@ class FATENetwork(FATENetworkCore):
 
         """
         input_layer = Input(shape=(n_objects, n_features), name="input_node")
-        set_repr = self.set_layer(input_layer)
+        set_repr = self.set_layer_(input_layer)
         scores = self.join_input_layers(
             input_layer,
             set_repr,
@@ -443,6 +441,11 @@ class FATENetwork(FATENetworkCore):
         self.random_state_ = check_random_state(self.random_state)
         self._initialize_optimizer()
         self._initialize_regularizer()
+        self._create_set_layers(
+            activation=self.activation,
+            kernel_initializer=self.kernel_initializer,
+            kernel_regularizer=self.kernel_regularizer_,
+        )
 
     def fit(
         self,
@@ -500,7 +503,6 @@ class FATENetwork(FATENetworkCore):
             **kwargs :
                 Keyword arguments for the fit function
         """
-        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         self._fit(
             X=X,
@@ -600,9 +602,9 @@ class FATENetwork(FATENetworkCore):
             shape=(n_objects, self.n_object_features_fit_), name="input_node"
         )
         if self.n_hidden_set_layers >= 1:
-            self.set_layer(input_layer_scorer)
-            fr = self.set_layer.cached_models[n_objects].predict(X, **kwargs)
-            del self.set_layer.cached_models[n_objects]
+            self.set_layer_(input_layer_scorer)
+            fr = self.set_layer_.cached_models[n_objects].predict(X, **kwargs)
+            del self.set_layer_.cached_models[n_objects]
             X_n = np.empty(
                 (fr.shape[0], n_objects, fr.shape[1] + self.n_object_features_fit_),
                 dtype="float",

--- a/csrank/core/fate_network.py
+++ b/csrank/core/fate_network.py
@@ -438,6 +438,12 @@ class FATENetwork(FATENetworkCore):
         )
         return model
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+        self._initialize_optimizer()
+        self._initialize_regularizer()
+
     def fit(
         self,
         X,
@@ -494,10 +500,8 @@ class FATENetwork(FATENetworkCore):
             **kwargs :
                 Keyword arguments for the fit function
         """
-        self.random_state_ = check_random_state(self.random_state)
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
-        self._initialize_optimizer()
-        self._initialize_regularizer()
         self._fit(
             X=X,
             Y=Y,

--- a/csrank/core/feta_linear.py
+++ b/csrank/core/feta_linear.py
@@ -136,6 +136,10 @@ class FETALinearCore(Learner):
             self.loss
         )
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+
     def fit(
         self, X, Y, epochs=10, callbacks=None, validation_split=0.1, verbose=0, **kwd
     ):
@@ -155,7 +159,7 @@ class FETALinearCore(Learner):
             predict the target variables and adjust its parameters by gradient
             descent `epochs` times.
         """
-        self.random_state_ = check_random_state(self.random_state)
+        self._pre_fit()
         # Global Variables Initializer
         n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         self._construct_model_(self.n_objects_fit_)

--- a/csrank/core/feta_network.py
+++ b/csrank/core/feta_network.py
@@ -264,6 +264,12 @@ class FETANetwork(Learner):
         )
         return model
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self._initialize_optimizer()
+        self._initialize_regularizer()
+        self.random_state_ = check_random_state(self.random_state)
+
     def fit(
         self, X, Y, epochs=10, callbacks=None, validation_split=0.1, verbose=0, **kwd
     ):
@@ -290,13 +296,11 @@ class FETANetwork(Learner):
             **kwd :
                 Keyword arguments for the fit function
         """
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
-        self._initialize_optimizer()
-        self._initialize_regularizer()
         self._construct_layers()
 
         logger.debug("Enter fit function...")
-        self.random_state_ = check_random_state(self.random_state)
 
         X, Y = self.sub_sampling(X, Y)
         self.model_ = self.construct_model()

--- a/csrank/core/pairwise_svm.py
+++ b/csrank/core/pairwise_svm.py
@@ -54,6 +54,10 @@ class PairwiseSVM(Learner):
         self.random_state = random_state
         self.fit_intercept = fit_intercept
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+
     def fit(self, X, Y, **kwargs):
         """
             Fit a generic preference learning model on a provided set of queries.
@@ -69,7 +73,7 @@ class PairwiseSVM(Learner):
                 Keyword arguments for the fit function
 
         """
-        self.random_state_ = check_random_state(self.random_state)
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         x_train, y_single = self._convert_instances_(X, Y)
         if self.use_logistic_regression:

--- a/csrank/core/ranknet_core.py
+++ b/csrank/core/ranknet_core.py
@@ -107,6 +107,12 @@ class RankNetCore(Learner):
     def _convert_instances_(self, X, Y):
         raise NotImplementedError
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+        self._initialize_optimizer()
+        self._initialize_regularizer()
+
     def fit(
         self, X, Y, epochs=10, callbacks=None, validation_split=0.1, verbose=0, **kwd
     ):
@@ -139,15 +145,13 @@ class RankNetCore(Learner):
             **kwd :
                 Keyword arguments for the fit function
         """
-        self.random_state_ = check_random_state(self.random_state)
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         X1, X2, Y_single = self._convert_instances_(X, Y)
 
         logger.debug("Instances created {}".format(X1.shape[0]))
         logger.debug("Creating the model")
 
-        self._initialize_optimizer()
-        self._initialize_regularizer()
         self._construct_layers()
 
         # Model with input as two objects and output as probability of x1>x2

--- a/csrank/discretechoice/baseline.py
+++ b/csrank/discretechoice/baseline.py
@@ -18,8 +18,12 @@ class RandomBaselineDC(DiscreteObjectChooser, Learner):
 
         self.random_state = random_state
 
-    def fit(self, X, Y, **kwd):
+    def _pre_fit(self):
+        super()._pre_fit()
         self.random_state_ = check_random_state(self.random_state)
+
+    def fit(self, X, Y, **kwd):
+        self._pre_fit()
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_instances, n_objects, n_features = X.shape

--- a/csrank/discretechoice/generalized_nested_logit.py
+++ b/csrank/discretechoice/generalized_nested_logit.py
@@ -328,6 +328,7 @@ class GeneralizedNestedLogitModel(DiscreteObjectChooser, Learner):
             **kwargs :
                 Keyword arguments for the fit function of :meth:`pymc3.fit`or :meth:`pymc3.sample`
         """
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         if self.n_nests is None:
             # TODO this looks like a bug to me, but it was already done this way

--- a/csrank/discretechoice/mixed_logit_model.py
+++ b/csrank/discretechoice/mixed_logit_model.py
@@ -214,6 +214,7 @@ class MixedLogitModel(DiscreteObjectChooser, Learner):
             **kwargs :
                 Keyword arguments for the fit function of :meth:`pymc3.fit`or :meth:`pymc3.sample`
         """
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         self.construct_model(X, Y)
         fit_pymc3_model(self, sampler, draws, tune, vi_params, **kwargs)

--- a/csrank/discretechoice/model_selector.py
+++ b/csrank/discretechoice/model_selector.py
@@ -58,6 +58,7 @@ class ModelSelector(metaclass=ABCMeta):
         self.models = dict()
 
     def fit(self, X, Y):
+        self._pre_fit()
         model_args = dict()
         for param_key in self.parameter_keys:
             model_args[param_key] = self.uniform_prior

--- a/csrank/discretechoice/multinomial_logit_model.py
+++ b/csrank/discretechoice/multinomial_logit_model.py
@@ -213,6 +213,7 @@ class MultinomialLogitModel(DiscreteObjectChooser, Learner):
             **kwargs :
                 Keyword arguments for the fit function of :meth:`pymc3.fit`or :meth:`pymc3.sample`
         """
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         self.construct_model(X, Y)
         fit_pymc3_model(self, sampler, draws, tune, vi_params, **kwargs)

--- a/csrank/discretechoice/nested_logit_model.py
+++ b/csrank/discretechoice/nested_logit_model.py
@@ -385,6 +385,7 @@ class NestedLogitModel(DiscreteObjectChooser, Learner):
             **kwargs :
                 Keyword arguments for the fit function of :meth:`pymc3.fit`or :meth:`pymc3.sample`
         """
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         if self.n_nests is None:
             self.n_nests = int(self.n_objects_fit_ / 2)

--- a/csrank/discretechoice/paired_combinatorial_logit.py
+++ b/csrank/discretechoice/paired_combinatorial_logit.py
@@ -270,6 +270,10 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
             )
         logger.info("Model construction completed")
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+
     def fit(
         self,
         X,
@@ -320,7 +324,7 @@ class PairedCombinatorialLogit(DiscreteObjectChooser, Learner):
            **kwargs :
                Keyword arguments for the fit function of :meth:`pymc3.fit`or :meth:`pymc3.sample`
        """
-        self.random_state_ = check_random_state(self.random_state)
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         self.nests_indices = np.array(
             list(combinations(np.arange(self.n_objects_fit_), 2))

--- a/csrank/discretechoice/pairwise_discrete_choice.py
+++ b/csrank/discretechoice/pairwise_discrete_choice.py
@@ -74,5 +74,6 @@ class PairwiseSVMDiscreteChoiceFunction(DiscreteObjectChooser, PairwiseSVM):
         return x_train, y_single
 
     def fit(self, X, Y, **kwd):
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         super().fit(X, Y, **kwd)

--- a/csrank/dyadranking/fate_dyad_ranker.py
+++ b/csrank/dyadranking/fate_dyad_ranker.py
@@ -5,7 +5,7 @@ from csrank.numpy_util import scores_to_rankings
 
 class FATEDyadRanker(FATENetwork, DyadRanker):
     def fit(self, Xo, Xc, Y, **kwargs):
-        pass
+        self._pre_fit()
 
     def predict_scores(self, Xo, Xc, **kwargs):
         return self.model_.predict([Xo, Xc], **kwargs)

--- a/csrank/learner.py
+++ b/csrank/learner.py
@@ -75,6 +75,21 @@ class Learner(BaseEstimator, metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def _pre_fit(self):
+        """Perform stateful initialization before fitting.
+
+        This function is for initialization that does not depend on the data,
+        but still requires some processing and therefore should not happen in
+        __init__. Examples include initialization of optimizers, construction
+        of NeuralNetwork layers (if it can be done without knowledge of the
+        data) etc.
+
+        You should always call this function before fit, even if you do not
+        override it. If you override it, you should call the super method first
+        so that general initializations can be inherited.
+        """
+        pass
+
     @abstractmethod
     def _predict_scores_fixed(self, X, **kwargs):
         """

--- a/csrank/objectranking/baseline.py
+++ b/csrank/objectranking/baseline.py
@@ -18,8 +18,12 @@ class RandomBaselineRanker(ObjectRanker, Learner):
 
         self.random_state = (random_state,)
 
-    def fit(self, X, Y, **kwd):
+    def _pre_fit(self):
+        super()._pre_fit()
         self.random_state_ = check_random_state(self.random_state)
+
+    def fit(self, X, Y, **kwd):
+        self._pre_fit()
 
     def _predict_scores_fixed(self, X, **kwargs):
         n_instances, n_objects, n_features = X.shape

--- a/csrank/objectranking/expected_rank_regression.py
+++ b/csrank/objectranking/expected_rank_regression.py
@@ -72,6 +72,10 @@ class ExpectedRankRegression(ObjectRanker, Learner):
         self.fit_intercept = fit_intercept
         self.random_state = random_state
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+
     def fit(self, X, Y, **kwargs):
         """
             Fit an ExpectedRankRegression on the provided set of queries X and preferences Y of those objects.
@@ -88,7 +92,7 @@ class ExpectedRankRegression(ObjectRanker, Learner):
             **kwargs
                 Keyword arguments for the fit function
         """
-        self.random_state_ = check_random_state(self.random_state)
+        self._pre_fit()
         logger.debug("Creating the Dataset")
         x_train, y_train = complete_linear_regression_dataset(X, Y)
         logger.debug("Finished the Dataset")

--- a/csrank/objectranking/list_net.py
+++ b/csrank/objectranking/list_net.py
@@ -139,6 +139,12 @@ class ListNet(ObjectRanker, Learner):
         Y_topk = Y[mask].reshape(n_inst, self.n_top)
         return X_topk, Y_topk
 
+    def _pre_fit(self):
+        super()._pre_fit()
+        self.random_state_ = check_random_state(self.random_state)
+        self._initialize_optimizer()
+        self._initialize_regularizer()
+
     def fit(
         self, X, Y, epochs=10, callbacks=None, validation_split=0.1, verbose=0, **kwd
     ):
@@ -172,10 +178,8 @@ class ListNet(ObjectRanker, Learner):
             **kwd
                 Keyword arguments for the fit function
         """
-        self.random_state_ = check_random_state(self.random_state)
+        self._pre_fit()
         _n_instances, _n_objects, self.n_object_features_fit_ = X.shape
-        self._initialize_optimizer()
-        self._initialize_regularizer()
         self._construct_layers()
         logger.debug("Creating top-k dataset")
         X, Y = self._create_topk(X, Y)

--- a/csrank/objectranking/rank_svm.py
+++ b/csrank/objectranking/rank_svm.py
@@ -58,6 +58,7 @@ class RankSVM(ObjectRanker, PairwiseSVM):
         logger.info("Initializing network")
 
     def fit(self, X, Y, **kwargs):
+        self._pre_fit()
         _n_instances, self.n_objects_fit_, self.n_object_features_fit_ = X.shape
         super().fit(X, Y, **kwargs)
 


### PR DESCRIPTION
###  Description

Creates a `_pre_fit` function to bridge the gap between `__init__` and `fit`: Everything which initializes some state, but does not actually depend on the data, belongs there. This separates concerns a bit and makes it possible to inherit those initializations.

I thought about making this an implicit wrapper (a wrapper defined in `learner` that inherits signature & docs and automatically prepends a call to `pre_fit` to every `fit` call). This might be possible with [`wrapt`](https://wrapt.readthedocs.io/en/latest/) and a [meta-class](https://stackoverflow.com/questions/8100166/inheriting-methods-docstrings-in-python), but it would be a little complex. Since it would also be less explicit, it might be a bit confusing for people who are not very familiar with the code. So I just went with an explicit call to `_pre_fit` for now.

I could imagine to automate the calls to `initialize_optimizer` and `initiialize_regularizer` in the future, but again I'm not entirely certain its desirable because it would feel a little "magic".

## Motivation and Context

https://github.com/kiudee/cs-ranking/pull/157#issuecomment-690261372

## How Has This Been Tested?

Pre-commit & test suite.

## Does this close/impact existing issues?

Impacts #94, #116, #146.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
