### PR TITLE
Setup nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+if ! has lorri; then
+	log_status "Using direnv's native nix support. Install lorri for better performance and caching."
+	use nix
+else
+	eval "$( lorri direnv )"
+fi

--- a/poetry.lock
+++ b/poetry.lock
@@ -19,6 +19,14 @@ version = "0.7.12"
 
 [[package]]
 category = "dev"
+description = "apipkg: namespace control and lazy-import mechanism"
+name = "apipkg"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.5"
+
+[[package]]
+category = "dev"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
 optional = false
@@ -308,6 +316,20 @@ name = "entrypoints"
 optional = false
 python-versions = ">=2.7"
 version = "0.3"
+
+[[package]]
+category = "dev"
+description = "execnet: rapid multi-Python deployment"
+name = "execnet"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.7.1"
+
+[package.dependencies]
+apipkg = ">=1.4"
+
+[package.extras]
+testing = ["pre-commit"]
 
 [[package]]
 category = "main"
@@ -1252,6 +1274,35 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+category = "dev"
+description = "run tests in isolated forked subprocesses"
+name = "pytest-forked"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.3.0"
+
+[package.dependencies]
+py = "*"
+pytest = ">=3.10"
+
+[[package]]
+category = "dev"
+description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
+name = "pytest-xdist"
+optional = false
+python-versions = ">=3.5"
+version = "2.1.0"
+
+[package.dependencies]
+execnet = ">=1.1"
+pytest = ">=6.0.0"
+pytest-forked = "*"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+testing = ["filelock"]
+
+[[package]]
 category = "main"
 description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
@@ -1879,10 +1930,10 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [extras]
-docs = ["Sphinx", "sphinx_rtd_theme", "sphinxcontrib-bibtex", "nbsphinx"]
+docs = ["Sphinx", "sphinx_rtd_theme", "sphinxcontrib-bibtex", "nbsphinx", "IPython"]
 
 [metadata]
-content-hash = "80bc9b7d9bafdf1ced072c843e2c673813c58fd034df98087d8284e950cd967c"
+content-hash = "0ee256f23317a4065c52ebe22255ab41bed1fe6496891e788448652f3f174d21"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -1894,6 +1945,10 @@ absl-py = [
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+apipkg = [
+    {file = "apipkg-1.5-py2.py3-none-any.whl", hash = "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"},
+    {file = "apipkg-1.5.tar.gz", hash = "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -1936,7 +1991,6 @@ backcall = [
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
 ]
 black = [
-    {file = "black-20.8b1-py3-none-any.whl", hash = "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"},
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 bleach = [
@@ -2055,6 +2109,10 @@ docutils = [
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
+]
+execnet = [
+    {file = "execnet-1.7.1-py2.py3-none-any.whl", hash = "sha256:d4efd397930c46415f62f8a31388d6be4f27a91d7550eb79bc64a756e0056547"},
+    {file = "execnet-1.7.1.tar.gz", hash = "sha256:cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50"},
 ]
 fastprogress = [
     {file = "fastprogress-1.0.0-py3-none-any.whl", hash = "sha256:474cd6a6e5b1c29a02383d709bf71f502477d0849bddc6ba5aa80b683f4ad16f"},
@@ -2608,6 +2666,14 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
     {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
+]
+pytest-forked = [
+    {file = "pytest-forked-1.3.0.tar.gz", hash = "sha256:6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca"},
+    {file = "pytest_forked-1.3.0-py2.py3-none-any.whl", hash = "sha256:dc4147784048e70ef5d437951728825a131b81714b398d5d52f17c7c144d8815"},
+]
+pytest-xdist = [
+    {file = "pytest-xdist-2.1.0.tar.gz", hash = "sha256:82d938f1a24186520e2d9d3a64ef7d9ac7ecdf1a0659e095d18e596b8cbd0672"},
+    {file = "pytest_xdist-2.1.0-py3-none-any.whl", hash = "sha256:7c629016b3bb006b88ac68e2b31551e7becf173c76b977768848e2bbed594d90"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ tox = "^3.19.0"
 pytest-cov = "^2.10.1"
 nbsphinx = "^0.7.1"
 IPython = "^7.18.1"
+pytest-xdist = "^2.1.0"
 
 [tool.poetry.extras]
 # These are temporarily made mandatory due to an issue in our optional imports.

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,31 @@
+{ # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
+  nixpkgs-rev ? "fc3766140c4b5369042515da67c9496762054e91"
+  # pin nixpkgs to the specified revision if not overridden
+, pkgsPath ? builtins.fetchTarball {
+    name = "nixpkgs-${nixpkgs-rev}";
+    url = "https://github.com/nixos/nixpkgs/archive/${nixpkgs-rev}.tar.gz";
+  }
+, pkgs ? import pkgsPath {}
+}:
+let
+  pythonEnv = pkgs.poetry2nix.mkPoetryEnv { 
+    projectDir = ./.;
+    # For tensorflow 1.15 https://github.com/nix-community/poetry2nix/issues/180
+    python = pkgs.python37;
+    overrides = pkgs.poetry2nix.overrides.withDefaults (self: super: {
+      # https://github.com/nix-community/poetry2nix/issues/166
+      sphinx-rtd-theme = super.sphinx_rtd_theme;
+      pillow = super.pillow.overridePythonAttrs (
+        old: {
+          # https://github.com/nix-community/poetry2nix/issues/180
+          buildInputs = with pkgs; [ xorg.libX11 ] ++ old.buildInputs;
+        }
+      );
+    });
+  };
+in pkgs.mkShell {
+  buildInputs = [
+    pythonEnv
+    pkgs.python37.pkgs.poetry
+  ];
+}


### PR DESCRIPTION
## Description

Now that we use poetry (#156), we can trivially add nix support as well using [poetry2nix](https://github.com/nix-community/poetry2nix). This re-uses the poetry lock file and makes the development environment available through nix as well. Advantages:

- very easy to use on NixOS or any system that has nix installed (linux/darwin/Windows with WSL). Simply execute `nix-shell --run pytest` to execute the test suite, setting up the environment as needed.
- efficient and reliable caching of dependencies.
- non-python dependencies are possible
- little overhead to the existing poetry setup
- very nice dev environment when using nix+direnv+lorri (`cd csrank` already sets up the proper env).

Its possible that we could improve the test runtime with nix+cachix, which would be future work.

## Motivation and Context

I've had an uncommitted `shell.nix` lying around in my directory for a long time to be able to easily set up the environment on NixOS. Now that we use poetry, that is much easier and no duplication is necessary anymore. Therefore I think its a good idea to commit it.

## How Has This Been Tested?

N/A

## Does this close/impact existing issues?

No.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
