### PR TITLE
Remove abstract marker on get_train_test_datasets

### DIFF
--- a/csrank/dataset_reader/dataset_reader.py
+++ b/csrank/dataset_reader/dataset_reader.py
@@ -138,7 +138,6 @@ class DatasetReader(metaclass=ABCMeta):
     def get_single_train_test_split(self):
         raise NotImplementedError
 
-    @abstractmethod
     def get_train_test_datasets(self, n_datasets=5):
         splits = np.array(n_datasets)
         return self.splitter(splits)


### PR DESCRIPTION
## Description

There is a default method implementation, so there is no reason to mark
it abstract. The marker makes it impossible to instantiate
ChoiceDatasetGenerator, which does not explicitly override the default
implementation.

Fixes #166

## How Has This Been Tested?

Testsuite & lints.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
