### PR TITLE
Pareto: Genereate unique centroids, documentation, test

### DIFF
--- a/csrank/dataset_reader/choicefunctions/choice_data_generator.py
+++ b/csrank/dataset_reader/choicefunctions/choice_data_generator.py
@@ -74,19 +74,40 @@ class ChoiceDatasetGenerator(SyntheticDatasetGenerator):
 
             return directions * lengths
 
-        def make_randn_pareto_choices(
-            n_instances=10000, n_features=2, n_objects=10, data_seed=None, center=0.0
+        def sample_pareto_from_isometric_normal(
+            n_points, dimension, center, random_state
         ):
-            """Generate random objects from a d-dimensional isometric normal distribution.
+            """Generate a Pareto problem from random objects.
+
+            Objects are drawn from a d-dimensional isometric normal
+            distribution.
 
             This should be the easiest possible Pareto-problem, since the model can learn
             a latent-utility which scores how likely a point is on the front (independent
-            of the other points)."""
-            rand = check_random_state(data_seed)
-            X = rand.randn(n_instances, n_objects, n_features)
-            Y = np.empty((n_instances, n_objects), dtype=bool)
-            for i in range(n_instances):
-                Y[i] = pareto_front(X[i])
+            of the other points).
+
+            Parameters
+            ----------
+            n_points : int
+                The number of points to sample.
+            dimension : int
+                The dimension of the space.
+            center : scalar or numpy array
+                An offset that will be added to every point.
+            random_state: np.random.RandomState
+                A numpy random state.
+
+            Returns
+            -------
+            X: numpy array of shape (n_points, dimension)
+                A list of points sampled from the d-dimensional isometric
+                normal distribution.
+            Y. numpy array of shape n_points
+                A binary flag array indicating whether or not the corresponding
+                point is part of the Pareto front.
+            """
+            X = random_state.randn(n_points, dimension)
+            Y = pareto_front(X)
             return X + center, Y
 
         rand = check_random_state(seed)
@@ -99,12 +120,11 @@ class ChoiceDatasetGenerator(SyntheticDatasetGenerator):
                 radius=cluster_spread,
                 random_state=rand,
             )
-            x, y = make_randn_pareto_choices(
-                n_instances=1,
-                n_features=n_features,
-                n_objects=n_objects,
-                data_seed=rand,
+            x, y = sample_pareto_from_isometric_normal(
+                n_points=n_objects,
+                dimension=n_features,
                 center=center,
+                random_state=rand,
             )
             X[i] = x
             Y[i] = y

--- a/csrank/dataset_reader/choicefunctions/choice_data_generator.py
+++ b/csrank/dataset_reader/choicefunctions/choice_data_generator.py
@@ -27,7 +27,6 @@ class ChoiceDatasetGenerator(SyntheticDatasetGenerator):
         n_objects=10,
         seed=42,
         cluster_spread=1.0,
-        cluster_size=10,
         **kwargs,
     ):
         def pareto_front(X, signs=None):
@@ -93,7 +92,7 @@ class ChoiceDatasetGenerator(SyntheticDatasetGenerator):
         rand = check_random_state(seed)
         X = np.empty((n_instances, n_objects, n_features))
         Y = np.empty((n_instances, n_objects), dtype=int)
-        for i in range(int(n_instances / cluster_size)):
+        for i in range(n_instances):
             center = sample_from_unit_ball(
                 n_points=1,
                 dimension=n_features,
@@ -101,14 +100,14 @@ class ChoiceDatasetGenerator(SyntheticDatasetGenerator):
                 random_state=rand,
             )
             x, y = make_randn_pareto_choices(
-                n_instances=cluster_size,
+                n_instances=1,
                 n_features=n_features,
                 n_objects=n_objects,
                 data_seed=rand,
                 center=center,
             )
-            X[i * cluster_size : (i + 1) * cluster_size] = x
-            Y[i * cluster_size : (i + 1) * cluster_size] = y
+            X[i] = x
+            Y[i] = y
         return X, Y
 
     def make_latent_linear_choices(

--- a/csrank/tests/test_pareto_dataset.py
+++ b/csrank/tests/test_pareto_dataset.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from csrank import ChoiceDatasetGenerator
+
+
+def test_pareto_problem_generation():
+    """A simple sanity check for Pareto problem generation."""
+    gen = ChoiceDatasetGenerator(
+        dataset_type="pareto",
+        random_state=42,
+        n_train_instances=11,
+        n_test_instances=1,
+        n_objects=3,
+        n_features=2,
+    )
+    X_train, Y_train, X_test, Y_test = gen.get_single_train_test_split()
+    assert X_train.shape == (11, 3, 2)
+    assert Y_train.shape == (11, 3)
+    assert X_test.shape == (1, 3, 2)
+
+    def is_binary_array(a):
+        return np.logical_or(a == 0, a == 1).all()
+
+    assert is_binary_array(Y_train)
+    assert is_binary_array(Y_test)


### PR DESCRIPTION
## Description

The Pareto problem generation re-used the same centroid for 10 times (which seems to be a bug) and generated invalid elements when `n_instances` was not a multiple of 10. This tries to fix these problems an adds some documentation on the things @kiudee cleared up for me. This is a result of https://github.com/kiudee/cs-ranking/pull/164#discussion_r522267387.


## How Has This Been Tested?

Ran the new test, relying on CI for the rest.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
