### PR TITLE
[WIP] Force travis-ci to use 3.7.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - 3.7 # Pinned since tensorflow 1.x is not available for python > 3.7
+    - 3.7.9 # Pinned since tensorflow 1.x is not available for python > 3.7
 
 cache:
   directories:
@@ -23,18 +23,18 @@ stages:
 jobs:
   fast_finish: true
   include:
-    - python: 3.7
+    - python: 3.7.9
       env: TOXENV=test1
-    - python: 3.7
+    - python: 3.7.9
       env: TOXENV=test2
-    - python: 3.7
+    - python: 3.7.9
       env: TOXENV=test3
-    - python: 3.7
+    - python: 3.7.9
       env: TOXENV=test4
-    - python: 3.7
+    - python: 3.7.9
       env: TOXENV=lint
     - stage: docs
-      python: 3.7
+      python: 3.7.9
       env: TOXENV=docs
 
 before_deploy:
@@ -47,6 +47,6 @@ deploy:
     script: poetry publish -v --build
     on:
       tags: true
-      python: 3.7
+      python: 3.7.9
       repo: kiudee/cs-ranking
       branch: master

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py37,lint,docs
 
 [travis]
 python =
-    3.7: py37
+    3.7.9: py37
 
 [testenv]
 passenv = SSH_AUTH_SOCK


### PR DESCRIPTION
Travis appears to be using 3.7.1, which causes failing builds.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request replaces the python version travis-ci uses (3.7), which appears to default to 3.7.1 instead of the latest version, by 3.7.9.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently the builds are failing, due to a bug present in 3.7.1 (example: https://github.com/kiudee/cs-ranking/pull/178/checks?check_run_id=2149548100).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Does this close/impact existing issues?
<!--- Please link to all relevant issues. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
