### PR TITLE
PyTorch migration: Add FETA estimators

### DIFF
--- a/csrank/choicefunction/__init__.py
+++ b/csrank/choicefunction/__init__.py
@@ -1,11 +1,13 @@
 from .baseline import AllPositive
 from .fate_choice import FATEChoiceFunction
+from .feta_choice import FETAChoiceFunction
 from .generalized_linear_model import GeneralizedLinearModel
 from .pairwise_choice import PairwiseSVMChoiceFunction
 
 __all__ = [
     "AllPositive",
     "FATEChoiceFunction",
+    "FETAChoiceFunction",
     "GeneralizedLinearModel",
     "PairwiseSVMChoiceFunction",
 ]

--- a/csrank/choicefunction/feta_choice.py
+++ b/csrank/choicefunction/feta_choice.py
@@ -1,0 +1,72 @@
+import functools
+
+import torch.nn as nn
+
+from csrank.choicefunction.choice_functions import SkorchChoiceFunction
+from csrank.modules.object_mapping import DenseNeuralNetwork
+from csrank.modules.scoring.feta import FETAScoring
+
+
+class FETAChoiceFunction(SkorchChoiceFunction):
+    """A variable choice estimator based on the FETA-Approach.
+
+    Parameters
+    ----------
+    n_hidden : int
+        The number of hidden layers that should be used in the pairwise utility
+        module and the zeroth order module (if enabled).
+
+    n_units : int
+        The number of units per hidden layer that should be used in the
+        pairwise utility module and the zeroth order module (if enabled).
+
+    add_zeroth_order_model : boolean
+        Whether or not to add a zeroth order utility model, i.e. a model that
+        evaluates an object independent from the context.
+
+    criterion : torch criterion (class)
+        The criterion that is used to evaluate and optimize the module.
+
+    **kwargs : skorch NeuralNet arguments
+        All keyword arguments are passed to the constructor of
+        ``SkorchChoiceFunction``. See the documentation of that class for more
+        details.
+    """
+
+    def __init__(
+        self,
+        n_hidden=2,
+        n_units=8,
+        add_zeroth_order_model=False,
+        activation=nn.SELU,
+        criterion=nn.BCELoss,
+        **kwargs
+    ):
+        self.n_hidden = n_hidden
+        self.n_units = n_units
+        self.add_zeroth_order_model = add_zeroth_order_model
+        self.activation = activation
+        super().__init__(module=FETAScoring, criterion=criterion, **kwargs)
+
+    def _get_extra_module_parameters(self):
+        """Return extra parameters that should be passed to the module."""
+        params = super()._get_extra_module_parameters()
+        params["pairwise_utility_module"] = functools.partial(
+            DenseNeuralNetwork,
+            hidden_layers=self.n_hidden,
+            units_per_hidden=self.n_units,
+            activation=self.activation(),
+            output_size=1,
+        )
+        params["zeroth_order_module"] = (
+            functools.partial(
+                DenseNeuralNetwork,
+                hidden_layers=self.n_hidden,
+                units_per_hidden=self.n_units,
+                activation=self.activation(),
+                output_size=1,
+            )
+            if self.add_zeroth_order_model
+            else None
+        )
+        return params

--- a/csrank/discretechoice/__init__.py
+++ b/csrank/discretechoice/__init__.py
@@ -1,5 +1,6 @@
 from .baseline import RandomBaselineDC
 from .fate_discrete_choice import FATEDiscreteChoiceFunction
+from .feta_discrete_choice import FETADiscreteChoiceFunction
 from .generalized_nested_logit import GeneralizedNestedLogitModel
 from .mixed_logit_model import MixedLogitModel
 from .model_selector import ModelSelector
@@ -10,6 +11,7 @@ from .pairwise_discrete_choice import PairwiseSVMDiscreteChoiceFunction
 
 __all__ = [
     "FATEDiscreteChoiceFunction",
+    "FETADiscreteChoiceFunction",
     "GeneralizedNestedLogitModel",
     "MixedLogitModel",
     "ModelSelector",

--- a/csrank/discretechoice/feta_discrete_choice.py
+++ b/csrank/discretechoice/feta_discrete_choice.py
@@ -1,0 +1,85 @@
+import functools
+
+import torch.nn as nn
+
+from csrank.discrete_choice_losses import CategoricalHingeLossMax
+from csrank.discretechoice.discrete_choice import SkorchDiscreteChoiceFunction
+from csrank.modules.object_mapping import DenseNeuralNetwork
+from csrank.modules.scoring.feta import FETAScoring
+
+
+class FETADiscreteChoiceFunction(SkorchDiscreteChoiceFunction):
+    """A discrete choice estimator based on the FETA-Approach.
+
+    Trains a model that first evaluates each object in contexts of limited size
+    and then aggregates these evaluations to arrive at a final
+    object-within-context evaluation.
+
+    The resulting model can then be used for context-sensitive choice.
+
+    Parameters
+    ----------
+    n_hidden : int
+        The number of hidden layers that should be used in the pairwise utility
+        module and the zeroth order module (if enabled).
+
+    n_units : int
+        The number of units per hidden layer that should be used in the
+        pairwise utility module and the zeroth order module (if enabled).
+
+    add_zeroth_order_model : boolean
+        Whether or not to add a zeroth order utility model, i.e. a model that
+        evaluates an object independent from the context.
+
+    choice_size : int
+        The size of the target choice set.
+
+    criterion : torch criterion (class)
+        The criterion that is used to evaluate and optimize the module.
+
+    **kwargs : skorch NeuralNet arguments
+        All keyword arguments are passed to the constructor of
+        ``SkorchDiscreteChoiceFunction``. See the documentation of that class
+        for more details.
+    """
+
+    def __init__(
+        self,
+        n_hidden=2,
+        n_units=8,
+        add_zeroth_order_model=False,
+        activation=nn.SELU,
+        choice_size=1,
+        criterion=CategoricalHingeLossMax,
+        **kwargs
+    ):
+        self.n_hidden = n_hidden
+        self.n_units = n_units
+        self.add_zeroth_order_model = add_zeroth_order_model
+        self.activation = activation
+        super().__init__(
+            module=FETAScoring, criterion=criterion, choice_size=choice_size, **kwargs
+        )
+
+    def _get_extra_module_parameters(self):
+        """Return extra parameters that should be passed to the module."""
+        params = super()._get_extra_module_parameters()
+        params["pairwise_utility_module"] = functools.partial(
+            DenseNeuralNetwork,
+            hidden_layers=self.n_hidden,
+            units_per_hidden=self.n_units,
+            activation=self.activation(),
+            output_size=1,
+        )
+        params["zeroth_order_module"] = (
+            functools.partial(
+                DenseNeuralNetwork,
+                hidden_layers=self.n_hidden,
+                units_per_hidden=self.n_units,
+                activation=self.activation(),
+                output_size=1,
+            )
+            if self.add_zeroth_order_model
+            else None
+        )
+        return params

--- a/csrank/modules/collection.py
+++ b/csrank/modules/collection.py
@@ -1,0 +1,134 @@
+"""Apply an evaluation function to instances and collect the results.
+
+The modules that are defined here should take a tensor of instances (shape
+:math:`(N, O, F)`, where :math:`N` is the number of instances, :math:`O` the
+number of objects per instance and :math:`F` the number of features per object)
+and apply some order :math:`k` utility function on all possible combinations of
+:math:`k` objects per instance. It should return an evaluation result matrix of
+shape :math:`(N, O^k)`.
+
+As an example, consider a pairwise preference function used together with
+``PairwiseEvaluation``. If you feed ``PairwiseEvaluation`` with a tensor of
+instances, you get back a tensor of preference matrices where the entry at
+indes :math:`(i, j)` tells you how preferable object :math:`i` is to object
+:math:`j`. You can then combine this result with a reduction to get a
+first-order (or order-:math:`k`) utility module. This is used in the
+``MeanAggregatedUtility`` first-order utility.
+"""
+
+import torch
+import torch.nn as nn
+
+
+def _generate_pairs(instances):
+    """Generate object pairs from instances.
+
+    This can be used to generate the individual comparisons in a first-order
+    utility function model.
+
+    >>> object_a = [0.5, 0.6]
+    >>> object_b = [1.5, 1.6]
+    >>> object_c = [2.5, 2.6]
+    >>> object_d = [3.5, 3.6]
+    >>> object_e = [4.5, 4.6]
+    >>> object_f = [5.5, 5.6]
+    >>> # instance = list of objects to rank
+    >>> instance_a = [object_a, object_b, object_c]
+    >>> instance_b = [object_d, object_e, object_f]
+    >>> instances = [instance_a, instance_b]
+
+    >>> _generate_pairs(torch.tensor(instances))
+    tensor([[[0.5000, 0.6000, 0.5000, 0.6000],
+             [0.5000, 0.6000, 1.5000, 1.6000],
+             [0.5000, 0.6000, 2.5000, 2.6000],
+             [1.5000, 1.6000, 0.5000, 0.6000],
+             [1.5000, 1.6000, 1.5000, 1.6000],
+             [1.5000, 1.6000, 2.5000, 2.6000],
+             [2.5000, 2.6000, 0.5000, 0.6000],
+             [2.5000, 2.6000, 1.5000, 1.6000],
+             [2.5000, 2.6000, 2.5000, 2.6000]],
+    <BLANKLINE>
+            [[3.5000, 3.6000, 3.5000, 3.6000],
+             [3.5000, 3.6000, 4.5000, 4.6000],
+             [3.5000, 3.6000, 5.5000, 5.6000],
+             [4.5000, 4.6000, 3.5000, 3.6000],
+             [4.5000, 4.6000, 4.5000, 4.6000],
+             [4.5000, 4.6000, 5.5000, 5.6000],
+             [5.5000, 5.6000, 3.5000, 3.6000],
+             [5.5000, 5.6000, 4.5000, 4.6000],
+             [5.5000, 5.6000, 5.5000, 5.6000]]])
+    """
+
+    def repeat_individual_objects(instances, times):
+        """Repeat each object once, immediately after the original."""
+        # add a dimension, so that each object is now enclosed in a singleton
+        unsqueezed = instances.unsqueeze(2)
+
+        # repeat every object (along the newly added dimension)
+        # ([[object_a], [object_a]], [[object_b]], [[object_b]])
+        repeated = unsqueezed.repeat(1, 1, times, 1)
+        # collapse the added dimension again so that each object is on the same
+        # level ([object_a], [object_a], [object_b]], [[object_b])
+        return repeated.view(instances.size(0), -1, instances.size(2))
+
+    def repeat_object_lists(instances, times):
+        """Repeat the whole object list as a unit (the same as "first" but in a different order)."""
+        return instances.repeat(1, times, 1)
+
+    n_objects = instances.size(1)
+    first = repeat_individual_objects(instances, n_objects)
+    second = repeat_object_lists(instances, n_objects)
+
+    # Glue the two together at the object level (the object's feature vectors
+    # are concatenated)
+    output_tensor = torch.cat((first, second), dim=2)
+    return output_tensor
+
+
+class PairwiseEvaluation(nn.Module):
+    """A module that applies a first-order utility to all object pairs.
+
+    This module receives a list of instances as an input:
+
+    >>> object_00 = [0.5, 0.6]
+    >>> object_01 = [1.5, 1.6]
+    >>> object_02 = [2.5, 2.6]
+    >>> object_10 = [3.5, 3.6]
+    >>> object_11 = [4.5, 4.6]
+    >>> object_12 = [5.5, 5.6]
+    >>> # instance = list of objects to rank
+    >>> instance_a = [object_00, object_01, object_02]
+    >>> instance_b = [object_10, object_11, object_12]
+    >>> instances = torch.tensor([instance_a, instance_b])
+    >>> n_features = instances.size(2)
+
+    And computes a list of *relations*, one relation for each instance. A
+    relation is a 2d array that contains a score for each pairwise object
+    combination.
+
+    >>> import numpy as np
+    >>> from csrank.modules.object_mapping import DeterministicSumming
+    >>> utility = PairwiseEvaluation(DeterministicSumming(2 * n_features))
+    >>> utilities = utility(torch.tensor(instances))
+    >>> utilities
+    tensor([[[ 2.2000,  4.2000,  6.2000],
+             [ 4.2000,  6.2000,  8.2000],
+             [ 6.2000,  8.2000, 10.2000]],
+    <BLANKLINE>
+            [[14.2000, 16.2000, 18.2000],
+             [16.2000, 18.2000, 20.2000],
+             [18.2000, 20.2000, 22.2000]]])
+    >>> utilities[0][0][1] == np.sum(object_00) + np.sum(object_01)
+    tensor(True)
+    """
+
+    def __init__(self, pairwise_model):
+        super().__init__()
+        self.pairwise_model = pairwise_model
+
+    def forward(self, instances):
+        n_instances = instances.size(0)
+        n_objects = instances.size(1)
+        object_pairs = _generate_pairs(instances)
+        scores = self.pairwise_model(object_pairs)
+        return scores.view(n_instances, n_objects, n_objects)

--- a/csrank/modules/instance_reduction.py
+++ b/csrank/modules/instance_reduction.py
@@ -61,3 +61,76 @@ class DeepSet(nn.Module):
         """
         embedded_objects = self.embedding_module(instances)
         return torch.mean(embedded_objects, dim=1)
+
+
+class MeanAggregatedUtility(nn.Module):
+    """Map instances to individual utilities by a first order utility function and aggregation.
+
+    This is an approximation of a generalized utility function as described in
+    section 3.1 of [1]_. This is the "Then Aggregate" part of FETA. Only
+    aggregation of first-order utility functions is supported.
+
+    Parameters
+    ----------
+    first_order_utility : torch module (instantiated)
+        A function that maps instances to a list of utility matrices. The
+        resulting matrix will be interpreted as the utility each object has,
+        given the context of the other object.
+
+        The function should expect input in the shape of [N, n_features] and
+        return output in the shape of [N]. That is, it should map a list of
+        concatenated object features to the pairwise utilities of these
+        objects.
+    exclude_self_comparison : bool
+        Whether or not to exclude the evaluations of the objects with
+        themselves (i.e. the diagonal values) when aggregating.
+
+    Returns
+    -------
+    A list of instances with the aggregated object utilities.
+
+    References
+    ----------
+    .. [1] Pfannschmidt, K., Gupta, P., & Hüllermeier, E. (2019). Learning
+    choice functions: Concepts and architectures. arXiv preprint
+    arXiv:1901.10860.
+    """
+
+    def __init__(self, first_order_utility, exclude_self_comparison):
+        super().__init__()
+        self.first_order_utility = first_order_utility
+        self.exclude_self_comparison = exclude_self_comparison
+
+    def forward(self, instances, **kwargs):
+        """Aggregate zeroth and first order utility, returning a 1d tensor of evaluations.
+
+        Parameters
+        ----------
+        instances : tensor
+            The input tensor of shape (N, *, O, F), where F is the number of
+            features and O is the number of objects.
+
+        Returns
+        -------
+        tensor
+            The aggregated utility of each object: A tensor of shape (N, *, O).
+        """
+        utility_matrix = self.first_order_utility(instances)
+        n_objects = utility_matrix.shape[-1]
+        n_instances = utility_matrix.shape[0]
+        if self.exclude_self_comparison:
+            # One diagonal unit matrix for each instance
+            diagonal_mask = (
+                torch.eye(n_objects, dtype=torch.uint8)
+                .view(1, n_objects, n_objects)
+                .repeat(n_instances, 1, 1)
+            )
+            # Fill the diagonal of each instance with 0 (to ignore it while
+            # summing).
+            utility_matrix[diagonal_mask] = 0
+            # The diagonal values do not count when computing the mean.
+            n_objects -= 1
+        # Compute the mean utility of each object, possibly ignoring the
+        # diagonal values.
+        context_utility = utility_matrix.sum(dim=-1) / n_objects
+        return context_utility

--- a/csrank/modules/scoring/__init__.py
+++ b/csrank/modules/scoring/__init__.py
@@ -10,5 +10,6 @@ examples.
 """
 
 from .fate import FATEScoring
+from .feta import FETAScoring
 
-__all__ = ["FATEScoring"]
+__all__ = ["FATEScoring", "FETAScoring"]

--- a/csrank/modules/scoring/feta.py
+++ b/csrank/modules/scoring/feta.py
@@ -1,0 +1,93 @@
+"""An implementation of the scoring module for FATE estimators."""
+
+import functools
+
+import torch.nn as nn
+
+from csrank.modules.collection import PairwiseEvaluation
+from csrank.modules.instance_reduction import MeanAggregatedUtility
+from csrank.modules.object_mapping import DenseNeuralNetwork
+
+
+class FETAScoring(nn.Module):
+    """Map instances to scores with the FETA approach.
+
+    >>> from csrank.modules.object_mapping import DeterministicSumming
+    >>> scoring = FETAScoring(
+    ...     n_features=2,
+    ...     pairwise_utility_module=DeterministicSumming,
+    ... )
+
+    Now let's define some problem instances.
+
+    >>> object_a = [0.5, 0.8]
+    >>> object_b = [1.5, 1.8]
+    >>> object_c = [2.5, 2.8]
+    >>> object_d = [3.5, 3.6]
+    >>> object_e = [4.5, 4.6]
+    >>> object_f = [5.5, 5.6]
+    >>> # instance = list of objects to rank
+    >>> instance_a = [object_a, object_b, object_c]
+    >>> instance_b = [object_d, object_e, object_f]
+    >>> import torch
+    >>> instances = torch.tensor([instance_a, instance_b])
+
+    >>> scoring(instances)
+    tensor([[ 5.6000,  6.6000,  7.6000],
+            [17.2000, 18.2000, 19.2000]])
+
+    Parameters
+    ----------
+    n_features: int
+        The number of features each object has.
+
+    pairwise_utility_module: pytorch module with one integer parameter
+        The module that should be used for pairwise utility estimations. Uses a
+        simple linear mapping if not specified. You likely want to replace this
+        with something more expressive such as a ``DenseNeuralNetwork``. This
+        should take the size of the input values as its only parameter. You can
+        use ``functools.partial`` if necessary. This corresponds to :math:`U`
+        [1]_.
+
+    zeroth_order_module: pytorch module with one integer parameter
+        The module that should be used to evaluate objects in isolation. May be
+        ``None``, in which case no zeroth order module is used. That is the
+        default behavior. You may want to replace this with something like a
+        ``DenseNeuralNetwork``. This should take the size of the input values
+        as its only parameter. You can use ``functools.partial`` if necessary.
+        This corresponds to :math:`U` This corresponds to :math:`U_0` [1]_.
+    """
+
+    def __init__(
+        self,
+        n_features,
+        pairwise_utility_module=functools.partial(
+            DenseNeuralNetwork, hidden_layers=3, units_per_hidden=20
+        ),
+        zeroth_order_module=None,
+    ):
+        super().__init__()
+        # Compute the utility of each object in the context of every other
+        # object. Use mean aggregation to come to a single utility value per
+        # object. Ignore self-comparisons. Including those would be similar to
+        # adding a zeroth-order model, but with a different scale and learned
+        # included in the same utility network. That could make it harder to
+        # learn.
+        self.mean_aggregated_utilty = MeanAggregatedUtility(
+            PairwiseEvaluation(pairwise_utility_module(2 * n_features)),
+            exclude_self_comparison=True,
+        )
+        self.zeroth_order_module = (
+            None if zeroth_order_module is None else zeroth_order_module(n_features)
+        )
+
+    def forward(self, instances, **kwargs):
+        total_utility = self.mean_aggregated_utilty(instances)
+        if self.zeroth_order_module is not None:
+            # The result of the zeroth order utility module has a singleton
+            # dimension, while the aggregated utility does not.
+            zeroth_order_utility = self.zeroth_order_module(instances).reshape(
+                total_utility.shape
+            )
+            total_utility += zeroth_order_utility
+        return total_utility

--- a/csrank/objectranking/__init__.py
+++ b/csrank/objectranking/__init__.py
@@ -1,11 +1,13 @@
 from .baseline import RandomBaselineRanker
 from .expected_rank_regression import ExpectedRankRegression
 from .fate_object_ranker import FATEObjectRanker
+from .feta_object_ranker import FETAObjectRanker
 from .rank_svm import RankSVM
 
 __all__ = [
     "ExpectedRankRegression",
     "FATEObjectRanker",
+    "FETAObjectRanker",
     "RandomBaselineRanker",
     "RankSVM",
 ]

--- a/csrank/objectranking/feta_object_ranker.py
+++ b/csrank/objectranking/feta_object_ranker.py
@@ -1,0 +1,80 @@
+import functools
+
+import torch.nn as nn
+
+from csrank.modules.object_mapping import DenseNeuralNetwork
+from csrank.modules.scoring.feta import FETAScoring
+from csrank.objectranking.object_ranker import SkorchObjectRanker
+from csrank.rank_losses import HingedRankLoss
+
+
+class FETAObjectRanker(SkorchObjectRanker):
+    """A ranking estimator based on the FETA-Approach.
+
+    Trains a model that first aggregates all objects into a context, then
+    evaluates each object within this context.
+
+    The resulting model can then be used for context-sensitive ranking.
+
+    Refer to skorch's documentation for supported parameters.
+
+    Parameters
+    ----------
+    n_hidden : int
+        The number of hidden layers that should be used in the pairwise utility
+        module and the zeroth order module (if enabled).
+
+    n_units : int
+        The number of units per hidden layer that should be used in the
+        pairwise utility module and the zeroth order module (if enabled).
+
+    add_zeroth_order_model : boolean
+        Whether or not to add a zeroth order utility model, i.e. a model that
+        evaluates an object independent from the context.
+
+    criterion : torch criterion (class)
+        The criterion that is used to evaluate and optimize the module.
+
+    **kwargs : skorch NeuralNet arguments
+        All keyword arguments are passed to the constructor of
+        ``SkorchObjectRanker``. See the documentation of that class for more
+        details.
+    """
+
+    def __init__(
+        self,
+        n_hidden=2,
+        n_units=8,
+        add_zeroth_order_model=False,
+        activation=nn.SELU,
+        criterion=HingedRankLoss,
+        **kwargs
+    ):
+        self.n_hidden = n_hidden
+        self.n_units = n_units
+        self.add_zeroth_order_model = add_zeroth_order_model
+        self.activation = activation
+        super().__init__(module=FETAScoring, criterion=criterion, **kwargs)
+
+    def _get_extra_module_parameters(self):
+        """Return extra parameters that should be passed to the module."""
+        params = super()._get_extra_module_parameters()
+        params["pairwise_utility_module"] = functools.partial(
+            DenseNeuralNetwork,
+            hidden_layers=self.n_hidden,
+            units_per_hidden=self.n_units,
+            activation=self.activation(),
+            output_size=1,
+        )
+        params["zeroth_order_module"] = (
+            functools.partial(
+                DenseNeuralNetwork,
+                hidden_layers=self.n_hidden,
+                units_per_hidden=self.n_units,
+                activation=self.activation(),
+                output_size=1,
+            )
+            if self.add_zeroth_order_model
+            else None
+        )
+        return params

--- a/csrank/tests/test_choice_functions.py
+++ b/csrank/tests/test_choice_functions.py
@@ -5,9 +5,11 @@ import torch
 from torch import optim
 
 from csrank.choicefunction import FATEChoiceFunction
+from csrank.choicefunction import FETAChoiceFunction
 from csrank.choicefunction import GeneralizedLinearModel
 from csrank.choicefunction import PairwiseSVMChoiceFunction
 from csrank.constants import FATE_CHOICE
+from csrank.constants import FETA_CHOICE
 from csrank.constants import GLM_CHOICE
 from csrank.constants import RANKSVM_CHOICE
 from csrank.metrics_np import auc_score
@@ -51,6 +53,27 @@ choice_functions = {
             **skorch_common_args,
         },
         get_vals([0.7177, 0.3119, 1.0]),
+    ),
+    FETA_CHOICE: (
+        FETAChoiceFunction,
+        {
+            "n_hidden": 1,
+            "n_units": 8,
+            "add_zeroth_order_model": False,
+            **skorch_common_args,
+        },
+        get_vals([0.8759, 0.8855, 1.0]),
+    ),
+    FETA_CHOICE
+    + "_zeroth_order_model": (
+        FETAChoiceFunction,
+        {
+            "n_hidden": 1,
+            "n_units": 8,
+            "add_zeroth_order_model": True,
+            **skorch_common_args,
+        },
+        get_vals([0.9368, 0.9617, 1.0]),
     ),
 }
 

--- a/csrank/tests/test_discrete_choice.py
+++ b/csrank/tests/test_discrete_choice.py
@@ -5,6 +5,7 @@ import torch
 from torch import optim
 
 from csrank.constants import FATE_DC
+from csrank.constants import FETA_DC
 from csrank.constants import GEV
 from csrank.constants import MLM
 from csrank.constants import MNL
@@ -13,6 +14,7 @@ from csrank.constants import PCL
 from csrank.constants import RANKSVM_DC
 from csrank.dataset_reader.discretechoice.util import convert_to_label_encoding
 from csrank.discretechoice import FATEDiscreteChoiceFunction
+from csrank.discretechoice import FETADiscreteChoiceFunction
 from csrank.discretechoice import GeneralizedNestedLogitModel
 from csrank.discretechoice import MixedLogitModel
 from csrank.discretechoice import MultinomialLogitModel
@@ -53,6 +55,27 @@ discrete_choice_functions = {
             "n_hidden_set_layers": 1,
             "n_hidden_joint_units": 5,
             "n_hidden_set_units": 5,
+            **skorch_common_args,
+        },
+        get_vals([1.0, 1.0]),
+    ),
+    FETA_DC: (
+        FETADiscreteChoiceFunction,
+        {
+            "n_hidden": 1,
+            "n_units": 8,
+            "add_zeroth_order_model": False,
+            **skorch_common_args,
+        },
+        get_vals([1.0, 1.0]),
+    ),
+    FETA_DC
+    + "zeroth_order_model": (
+        FETADiscreteChoiceFunction,
+        {
+            "n_hidden": 1,
+            "n_units": 8,
+            "add_zeroth_order_model": True,
             **skorch_common_args,
         },
         get_vals([1.0, 1.0]),

--- a/csrank/tests/test_ranking.py
+++ b/csrank/tests/test_ranking.py
@@ -5,11 +5,13 @@ from torch import optim
 
 from csrank.constants import ERR
 from csrank.constants import FATE_RANKER
+from csrank.constants import FETA_RANKER
 from csrank.constants import RANKSVM
 from csrank.metrics_np import zero_one_accuracy_np
 from csrank.metrics_np import zero_one_rank_loss_for_scores_ties_np
 from csrank.objectranking import ExpectedRankRegression
 from csrank.objectranking import FATEObjectRanker
+from csrank.objectranking import FETAObjectRanker
 from csrank.objectranking import RankSVM
 
 skorch_common_args = {
@@ -33,6 +35,27 @@ object_rankers = {
             "n_hidden_set_layers": 1,
             "n_hidden_joint_units": 5,
             "n_hidden_set_units": 5,
+            **skorch_common_args,
+        },
+        (0.0, 1.0),
+    ),
+    FETA_RANKER: (
+        FETAObjectRanker,
+        {
+            "n_hidden": 1,
+            "n_units": 8,
+            "add_zeroth_order_model": False,
+            **skorch_common_args,
+        },
+        (0.0, 1.0),
+    ),
+    FETA_RANKER
+    + "zeroth_order_model": (
+        FETAObjectRanker,
+        {
+            "n_hidden": 1,
+            "n_units": 8,
+            "add_zeroth_order_model": True,
             **skorch_common_args,
         },
         (0.0, 1.0),


### PR DESCRIPTION
## Description

This adds pytorch versions of the FETA estimators. ~It builds on (and currently includes the commits of) #164, which should be reviewed first.~ This is now ready for review.

## Motivation and Context

Part of the ongoing pytorch migration.

## How Has This Been Tested?

I have added the FETA estimators to the existing tests for discrete choice, general choice and object ranking. I used the test suite and the linters to check the changes.

## Does this close/impact existing issues?

Related to #125.

## Types of changes

This depends on what you consider as the base. It is a new feature for the pytorch migration branch, but a breaking change on master.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
