### PR TITLE
PyTorch migration: Add CmpNet estimators

### DIFF
--- a/csrank/choicefunction/__init__.py
+++ b/csrank/choicefunction/__init__.py
@@ -1,4 +1,5 @@
 from .baseline import AllPositive
+from .cmpnet_choice import CmpNetChoiceFunction
 from .fate_choice import FATEChoiceFunction
 from .feta_choice import FETAChoiceFunction
 from .generalized_linear_model import GeneralizedLinearModel
@@ -6,6 +7,7 @@ from .pairwise_choice import PairwiseSVMChoiceFunction
 
 __all__ = [
     "AllPositive",
+    "CmpNetChoiceFunction",
     "FATEChoiceFunction",
     "FETAChoiceFunction",
     "GeneralizedLinearModel",

--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -36,12 +36,7 @@ class CmpNetChoiceFunction(SkorchChoiceFunction):
     """
 
     def __init__(
-        self,
-        n_hidden=2,
-        n_units=8,
-        criterion=nn.BCELoss,
-        activation=nn.ReLU,
-        **kwargs
+        self, n_hidden=2, n_units=8, criterion=nn.BCELoss, activation=nn.ReLU, **kwargs
     ):
         self.n_hidden = n_hidden
         self.n_units = n_units

--- a/csrank/choicefunction/cmpnet_choice.py
+++ b/csrank/choicefunction/cmpnet_choice.py
@@ -1,0 +1,61 @@
+import functools
+
+import torch.nn as nn
+
+from csrank.choicefunction.choice_functions import SkorchChoiceFunction
+from csrank.modules.object_mapping import DenseNeuralNetwork
+from csrank.modules.scoring.cmpnet import CmpNetScoring
+
+
+class CmpNetChoiceFunction(SkorchChoiceFunction):
+    """A variable choice estimator based on the CmpNet-Approach.
+
+    See the documentation of the ``CmpNetScoring`` class for more details.
+
+    Parameters
+    ----------
+    n_hidden : int
+        The number of hidden layers that should be used in the pairwise utility
+        module and the zeroth order module (if enabled).
+
+    n_units : int
+        The number of units per hidden layer that should be used in the
+        pairwise utility module and the zeroth order module (if enabled).
+
+    activation : torch activation function (class)
+        The activation function that should be used for each layer of the
+        comparative network.
+
+    criterion : torch criterion (class)
+        The criterion that is used to evaluate and optimize the module.
+
+    **kwargs : skorch NeuralNet arguments
+        All keyword arguments are passed to the constructor of
+        ``SkorchChoiceFunction``. See the documentation of that class for more
+        details.
+    """
+
+    def __init__(
+        self,
+        n_hidden=2,
+        n_units=8,
+        criterion=nn.BCELoss,
+        activation=nn.ReLU,
+        **kwargs
+    ):
+        self.n_hidden = n_hidden
+        self.n_units = n_units
+        self.activation = activation
+        super().__init__(module=CmpNetScoring, criterion=criterion, **kwargs)
+
+    def _get_extra_module_parameters(self):
+        """Return extra parameters that should be passed to the module."""
+        params = super()._get_extra_module_parameters()
+        params["pairwise_preference_core"] = functools.partial(
+            DenseNeuralNetwork,
+            hidden_layers=self.n_hidden,
+            units_per_hidden=self.n_units,
+            activation=self.activation(),
+        )
+        params["core_encoding_size"] = self.n_hidden
+        return params

--- a/csrank/discretechoice/__init__.py
+++ b/csrank/discretechoice/__init__.py
@@ -1,4 +1,5 @@
 from .baseline import RandomBaselineDC
+from .cmpnet_discrete_choice import CmpNetDiscreteChoiceFunction
 from .fate_discrete_choice import FATEDiscreteChoiceFunction
 from .feta_discrete_choice import FETADiscreteChoiceFunction
 from .generalized_nested_logit import GeneralizedNestedLogitModel
@@ -10,6 +11,7 @@ from .paired_combinatorial_logit import PairedCombinatorialLogit
 from .pairwise_discrete_choice import PairwiseSVMDiscreteChoiceFunction
 
 __all__ = [
+    "CmpNetDiscreteChoiceFunction",
     "FATEDiscreteChoiceFunction",
     "FETADiscreteChoiceFunction",
     "GeneralizedNestedLogitModel",

--- a/csrank/discretechoice/cmpnet_discrete_choice.py
+++ b/csrank/discretechoice/cmpnet_discrete_choice.py
@@ -1,0 +1,68 @@
+import functools
+
+import torch.nn as nn
+
+from csrank.discrete_choice_losses import CategoricalHingeLossMax
+from csrank.discretechoice.discrete_choice import SkorchDiscreteChoiceFunction
+from csrank.modules.object_mapping import DenseNeuralNetwork
+from csrank.modules.scoring.cmpnet import CmpNetScoring
+
+
+class CmpNetDiscreteChoiceFunction(SkorchDiscreteChoiceFunction):
+    """A discrete choice estimator based on the CmpNet-Approach.
+
+    See the documentation of the ``CmpNetScoring`` class for more details.
+
+    Parameters
+    ----------
+    n_hidden : int
+        The number of hidden layers that should be used in the pairwise utility
+        module and the zeroth order module (if enabled).
+
+    n_units : int
+        The number of units per hidden layer that should be used in the
+        pairwise utility module and the zeroth order module (if enabled).
+
+    choice_size : int
+        The size of the target choice set.
+
+    activation : torch activation function (class)
+        The activation function that should be used for each layer of the
+        comparative network.
+
+    criterion : torch criterion (class)
+        The criterion that is used to evaluate and optimize the module.
+
+    **kwargs : skorch NeuralNet arguments
+        All keyword arguments are passed to the constructor of
+        ``SkorchDiscreteChoiceFunction``. See the documentation of that class
+        for more details.
+    """
+
+    def __init__(
+        self,
+        n_hidden=2,
+        n_units=8,
+        criterion=CategoricalHingeLossMax,
+        activation=nn.ReLU,
+        choice_size=1,
+        **kwargs
+    ):
+        self.n_hidden = n_hidden
+        self.n_units = n_units
+        self.activation = activation
+        super().__init__(
+            module=CmpNetScoring, criterion=criterion, choice_size=choice_size, **kwargs
+        )
+
+    def _get_extra_module_parameters(self):
+        """Return extra parameters that should be passed to the module."""
+        params = super()._get_extra_module_parameters()
+        params["pairwise_preference_core"] = functools.partial(
+            DenseNeuralNetwork,
+            hidden_layers=self.n_hidden,
+            units_per_hidden=self.n_units,
+            activation=self.activation(),
+        )
+        params["core_encoding_size"] = self.n_hidden
+        return params

--- a/csrank/modules/scoring/__init__.py
+++ b/csrank/modules/scoring/__init__.py
@@ -9,7 +9,8 @@ the implemented pytorch estimators such as ``FATEDiscreteObjectChooser`` for
 examples.
 """
 
+from .cmpnet import CmpNetScoring
 from .fate import FATEScoring
 from .feta import FETAScoring
 
-__all__ = ["FATEScoring", "FETAScoring"]
+__all__ = ["CmpNetScoring", "FATEScoring", "FETAScoring"]

--- a/csrank/modules/scoring/cmpnet.py
+++ b/csrank/modules/scoring/cmpnet.py
@@ -1,0 +1,72 @@
+"""An implementation of the scoring module for FATE estimators."""
+
+import functools
+
+import torch.nn as nn
+
+from csrank.modules.collection import PairwiseEvaluation
+from csrank.modules.instance_reduction import MeanAggregatedUtility
+from csrank.modules.object_mapping import CmpNN
+from csrank.modules.object_mapping import DenseNeuralNetwork
+
+
+class CmpNetScoring(nn.Module):
+    r"""Map instances to scores with the CmpNet approach.
+
+    This approach was introduced in [1]_. It is very similar to the FETA (first
+    evaluate, then aggregate) approach. It uses a ``CmpNet`` for evaluation.
+    The network returns pairwise "evidence" that the first object is preferable
+    to the second one. That is conceptually the inverse of a pairwise utility
+    ("how much does the presence of one object support the utility of
+    another?"), but we can ignore that in the implementation since the two are
+    equivalently learnable by a neural network. The ``CmpNet`` does not return
+    preferences directly but rather "evidence" for preference. That means that
+    the preferences are not normalized, which again does not matter for the
+    relative scores.
+
+    The evidences of one object against all others are then aggregated by a
+    mean reduction, resulting in something similar to a Borda score for each
+    object. These scores can be used for ranking and choice tasks. Not that
+    this differs from the sorting approach taken in [1]_.
+
+    The main practical difference to the FETA approach is the weight-sharing in
+    the evaluation. See the documentation of ``CmpNet`` for details.
+
+    Parameters
+    ----------
+    n_features: int
+        The number of features each object has.
+    pairwise_preference_core: instantiated pytorch module
+        This module is used for the pairwise evaluations. The original paper
+        [1]_ suggests to use a simple linear layer. This module should expect
+        an input of shape :math:`(N, 2 \cdot F)` where :math:`F` is the size of
+        a feature vector, and produce an output of shape :math:`(N, C)` where
+        :math:`C` is the core output size. The output will be further processed
+        by the ``CmpNet``.
+    core_encoding_size: int
+        The size of the embedding that the pairwise preference core should
+        produce before the results are aggregated by the final layer. See the
+        documentation of ``CmpNet`` for a more detailed understanding.
+    """
+
+    def __init__(
+        self,
+        n_features,
+        pairwise_preference_core=functools.partial(
+            DenseNeuralNetwork, hidden_layers=1, units_per_hidden=8
+        ),
+        core_encoding_size=8,
+    ):
+        super().__init__()
+        self.mean_aggregated_evidence = MeanAggregatedUtility(
+            PairwiseEvaluation(
+                CmpNN(
+                    pairwise_preference_core(2 * n_features, core_encoding_size),
+                    core_encoding_size=core_encoding_size,
+                )
+            ),
+            exclude_self_comparison=True,
+        )
+
+    def forward(self, instances, **kwargs):
+        return self.mean_aggregated_evidence(instances)

--- a/csrank/objectranking/__init__.py
+++ b/csrank/objectranking/__init__.py
@@ -1,10 +1,12 @@
 from .baseline import RandomBaselineRanker
+from .cmpnet_object_ranker import CmpNetObjectRanker
 from .expected_rank_regression import ExpectedRankRegression
 from .fate_object_ranker import FATEObjectRanker
 from .feta_object_ranker import FETAObjectRanker
 from .rank_svm import RankSVM
 
 __all__ = [
+    "CmpNetObjectRanker",
     "ExpectedRankRegression",
     "FATEObjectRanker",
     "FETAObjectRanker",

--- a/csrank/objectranking/cmpnet_object_ranker.py
+++ b/csrank/objectranking/cmpnet_object_ranker.py
@@ -1,0 +1,62 @@
+import functools
+
+import torch.nn as nn
+
+from csrank.modules.object_mapping import DenseNeuralNetwork
+from csrank.modules.scoring.cmpnet import CmpNetScoring
+from csrank.objectranking.object_ranker import SkorchObjectRanker
+from csrank.rank_losses import HingedRankLoss
+
+
+class CmpNetObjectRanker(SkorchObjectRanker):
+    """A object ranking estimator based on the CmpNet-Approach.
+
+    See the documentation of the ``CmpNetScoring`` class for more details.
+
+    Parameters
+    ----------
+    n_hidden : int
+        The number of hidden layers that should be used in the pairwise utility
+        module and the zeroth order module (if enabled).
+
+    n_units : int
+        The number of units per hidden layer that should be used in the
+        pairwise utility module and the zeroth order module (if enabled).
+
+    activation : torch activation function (class)
+        The activation function that should be used for each layer of the
+        comparative network.
+
+    criterion : torch criterion (class)
+        The criterion that is used to evaluate and optimize the module.
+
+    **kwargs : skorch NeuralNet arguments
+        All keyword arguments are passed to the constructor of
+        ``SkorchChoiceFunction``. See the documentation of that class for more
+        details.
+    """
+
+    def __init__(
+        self,
+        n_hidden=2,
+        n_units=8,
+        criterion=HingedRankLoss,
+        activation=nn.ReLU,
+        **kwargs
+    ):
+        self.n_hidden = n_hidden
+        self.n_units = n_units
+        self.activation = activation
+        super().__init__(module=CmpNetScoring, criterion=criterion, **kwargs)
+
+    def _get_extra_module_parameters(self):
+        """Return extra parameters that should be passed to the module."""
+        params = super()._get_extra_module_parameters()
+        params["pairwise_preference_core"] = functools.partial(
+            DenseNeuralNetwork,
+            hidden_layers=self.n_hidden,
+            units_per_hidden=self.n_units,
+            activation=self.activation(),
+        )
+        params["core_encoding_size"] = self.n_hidden
+        return params

--- a/csrank/tests/test_choice_functions.py
+++ b/csrank/tests/test_choice_functions.py
@@ -4,10 +4,12 @@ import pytest
 import torch
 from torch import optim
 
+from csrank.choicefunction import CmpNetChoiceFunction
 from csrank.choicefunction import FATEChoiceFunction
 from csrank.choicefunction import FETAChoiceFunction
 from csrank.choicefunction import GeneralizedLinearModel
 from csrank.choicefunction import PairwiseSVMChoiceFunction
+from csrank.constants import CMPNET_CHOICE
 from csrank.constants import FATE_CHOICE
 from csrank.constants import FETA_CHOICE
 from csrank.constants import GLM_CHOICE
@@ -41,6 +43,17 @@ skorch_common_args = {
 }
 
 choice_functions = {
+    CMPNET_CHOICE: (
+        CmpNetChoiceFunction,
+        {"n_hidden": 2, "n_units": 8, **skorch_common_args},
+        # The performance looks bad, but this is likely just due to the small
+        # test set and the variance in the results. We get much better
+        # performance when using SELU instead of ReLU here, but we don't want
+        # to tweak the configuration for this particular test just to get good
+        # looking numbers. This is just a sanity check, the numbers are not
+        # representative.
+        get_vals([0.1962, 0.1609, 1.0]),
+    ),
     GLM_CHOICE: (GeneralizedLinearModel, {}, get_vals([0.9567, 0.9955, 1.0])),
     RANKSVM_CHOICE: (PairwiseSVMChoiceFunction, {}, get_vals([0.9522, 0.9955, 1.0])),
     FATE_CHOICE: (

--- a/csrank/tests/test_choice_functions.py
+++ b/csrank/tests/test_choice_functions.py
@@ -48,10 +48,11 @@ choice_functions = {
         {"n_hidden": 2, "n_units": 8, **skorch_common_args},
         # The performance looks bad, but this is likely just due to the small
         # test set and the variance in the results. We get much better
-        # performance when using SELU instead of ReLU here, but we don't want
-        # to tweak the configuration for this particular test just to get good
-        # looking numbers. This is just a sanity check, the numbers are not
-        # representative.
+        # performance when using SELU instead of ReLU here. Increasing the
+        # number of epochs has a similar effect. We stick to the current
+        # configuration because we don't want to tweak the configuration for
+        # this particular test just to get good looking numbers. This is just a
+        # sanity check, the numbers are not representative.
         get_vals([0.1962, 0.1609, 1.0]),
     ),
     GLM_CHOICE: (GeneralizedLinearModel, {}, get_vals([0.9567, 0.9955, 1.0])),

--- a/csrank/tests/test_discrete_choice.py
+++ b/csrank/tests/test_discrete_choice.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from torch import optim
 
+from csrank.constants import CMPNET_DC
 from csrank.constants import FATE_DC
 from csrank.constants import FETA_DC
 from csrank.constants import GEV
@@ -13,6 +14,7 @@ from csrank.constants import NLM
 from csrank.constants import PCL
 from csrank.constants import RANKSVM_DC
 from csrank.dataset_reader.discretechoice.util import convert_to_label_encoding
+from csrank.discretechoice import CmpNetDiscreteChoiceFunction
 from csrank.discretechoice import FATEDiscreteChoiceFunction
 from csrank.discretechoice import FETADiscreteChoiceFunction
 from csrank.discretechoice import GeneralizedNestedLogitModel
@@ -48,6 +50,11 @@ skorch_common_args = {
 }
 
 discrete_choice_functions = {
+    CMPNET_DC: (
+        CmpNetDiscreteChoiceFunction,
+        {"n_hidden": 2, "n_units": 8, **skorch_common_args},
+        get_vals([1.0, 1.0]),
+    ),
     FATE_DC: (
         FATEDiscreteChoiceFunction,
         {

--- a/csrank/tests/test_ranking.py
+++ b/csrank/tests/test_ranking.py
@@ -3,12 +3,14 @@ import pytest
 import torch
 from torch import optim
 
+from csrank.constants import CMPNET
 from csrank.constants import ERR
 from csrank.constants import FATE_RANKER
 from csrank.constants import FETA_RANKER
 from csrank.constants import RANKSVM
 from csrank.metrics_np import zero_one_accuracy_np
 from csrank.metrics_np import zero_one_rank_loss_for_scores_ties_np
+from csrank.objectranking import CmpNetObjectRanker
 from csrank.objectranking import ExpectedRankRegression
 from csrank.objectranking import FATEObjectRanker
 from csrank.objectranking import FETAObjectRanker
@@ -26,6 +28,11 @@ skorch_common_args = {
 }
 
 object_rankers = {
+    CMPNET: (
+        CmpNetObjectRanker,
+        {"n_hidden": 2, "n_units": 8, **skorch_common_args},
+        (0.0, 1.0),
+    ),
     ERR: (ExpectedRankRegression, {}, (0.0, 1.0)),
     RANKSVM: (RankSVM, {}, (0.0, 1.0)),
     FATE_RANKER: (


### PR DESCRIPTION
## Description

This adds pytorch versions of the CmpNet estimators. ~It builds on (and currently includes the commits of) #164 and #183, which should be reviewed first.~ I thought these PRs could be reviewed more independently, but it turns out that CmpNet heavily depends on the components that were introduced for FETA.

This is now ready for review.

## Motivation and Context

Part of the ongoing pytorch migration.

## How Has This Been Tested?

I have added the CmpNet estimators to the existing tests for discrete choice, general choice and object ranking. I have checked the changes with our set of linters and the test suite.

## Does this close/impact existing issues?

Related to #125.

## Types of changes

This depends on what you consider as the base. It is a new feature for the pytorch migration branch, but a breaking change on master.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
