### PR TITLE
Add missing activation documentation for FETA

### DIFF
--- a/csrank/choicefunction/feta_choice.py
+++ b/csrank/choicefunction/feta_choice.py
@@ -24,6 +24,10 @@ class FETAChoiceFunction(SkorchChoiceFunction):
         Whether or not to add a zeroth order utility model, i.e. a model that
         evaluates an object independent from the context.
 
+    activation : torch activation function (class)
+        The activation function that should be used for each layer of the
+        pairwise utility module and the zeroth order module (if enabled).
+
     criterion : torch criterion (class)
         The criterion that is used to evaluate and optimize the module.
 

--- a/csrank/discretechoice/feta_discrete_choice.py
+++ b/csrank/discretechoice/feta_discrete_choice.py
@@ -31,6 +31,10 @@ class FETADiscreteChoiceFunction(SkorchDiscreteChoiceFunction):
         Whether or not to add a zeroth order utility model, i.e. a model that
         evaluates an object independent from the context.
 
+    activation : torch activation function (class)
+        The activation function that should be used for each layer of the
+        pairwise utility module and the zeroth order module (if enabled).
+
     choice_size : int
         The size of the target choice set.
 

--- a/csrank/objectranking/feta_object_ranker.py
+++ b/csrank/objectranking/feta_object_ranker.py
@@ -32,6 +32,10 @@ class FETAObjectRanker(SkorchObjectRanker):
         Whether or not to add a zeroth order utility model, i.e. a model that
         evaluates an object independent from the context.
 
+    activation : torch activation function (class)
+        The activation function that should be used for each layer of the
+        pairwise utility module and the zeroth order module (if enabled).
+
     criterion : torch criterion (class)
         The criterion that is used to evaluate and optimize the module.
 


### PR DESCRIPTION
## Description

I missed documentation for the `activation` parameter when adding the FETA based estimators in #183.

## Motivation and Context

See description.

## How Has This Been Tested?

I ran the linters.

## Does this close/impact existing issues?

No issues, but this is a follow up to #183.

## Types of changes

"Bug fix" is the closest match. This does not affect the functionality though.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
