### PR TITLE
PyTorch migration: Add RankNet estimators

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,11 @@ History
 * The RankNet and CmpNet estimators are now trained with a loss that applies to
   the whole result (the general/discrete choice or ranking). They were
   previously trained on object pairs with different loss functions.
+
+* Behavior and default parameters of the estimators may differ from the
+  previous versions. For example the default RankNet activation is now SELU
+  instead of ReLU.
+
 1.3.0 (Unreleased)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ History
   likely need to adapt to this new version if you have been using estimators
   from version 1.x.
 
+* The RankNet and CmpNet estimators are now trained with a loss that applies to
+  the whole result (the general/discrete choice or ranking). They were
+  previously trained on object pairs with different loss functions.
 1.3.0 (Unreleased)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ We implement the following new object ranking/choice architectures:
 
 In addition, we also implement these algorithms for choice functions:
 
-* RankNetChoiceFunction (currently not available due to the PyTorch migration)
+* RankNetChoiceFunction
 * GeneralizedLinearModel
 * PairwiseSVMChoiceFunction
 
@@ -34,8 +34,7 @@ setting:
 * MixedLogitModel
 * NestedLogitModel
 * PairedCombinatorialLogit
-* RankNetDiscreteChoiceFunction (currently not available due to the PyTorch
-  migration)
+* RankNetDiscreteChoiceFunction
 * PairwiseSVMDiscreteChoiceFunction
 
 

--- a/csrank/choicefunction/__init__.py
+++ b/csrank/choicefunction/__init__.py
@@ -4,6 +4,7 @@ from .fate_choice import FATEChoiceFunction
 from .feta_choice import FETAChoiceFunction
 from .generalized_linear_model import GeneralizedLinearModel
 from .pairwise_choice import PairwiseSVMChoiceFunction
+from .ranknet_choice import RankNetChoiceFunction
 
 __all__ = [
     "AllPositive",
@@ -12,4 +13,5 @@ __all__ = [
     "FETAChoiceFunction",
     "GeneralizedLinearModel",
     "PairwiseSVMChoiceFunction",
+    "RankNetChoiceFunction",
 ]

--- a/csrank/choicefunction/ranknet_choice.py
+++ b/csrank/choicefunction/ranknet_choice.py
@@ -1,0 +1,55 @@
+import functools
+
+import torch.nn as nn
+
+from csrank.choicefunction.choice_functions import SkorchChoiceFunction
+from csrank.modules.object_mapping import DenseNeuralNetwork
+from csrank.modules.scoring.ranknet import RankNetScoring
+
+
+class RankNetChoiceFunction(SkorchChoiceFunction):
+    """A variable choice estimator based on the RankNet-Approach.
+
+    See the documentation of the ``RankNetScoring`` class for more details.
+
+    Parameters
+    ----------
+    n_hidden : int
+        The number of hidden layers that should be used in the utility module.
+
+    n_units : int
+        The number of units per hidden layer that should be used in the utility
+        module.
+
+    activation : torch activation function (class)
+        The activation function that should be used for each layer of the
+        comparative network.
+
+    criterion : torch criterion (class)
+        The criterion that is used to evaluate and optimize the module.
+
+    **kwargs : skorch NeuralNet arguments
+        All keyword arguments are passed to the constructor of
+        ``SkorchChoiceFunction``. See the documentation of that class for more
+        details.
+    """
+
+    def __init__(
+        self, n_hidden=2, n_units=8, activation=nn.SELU, criterion=nn.BCELoss, **kwargs
+    ):
+        self.n_hidden = n_hidden
+        self.n_units = n_units
+        self.activation = activation
+        super().__init__(module=RankNetScoring, criterion=criterion, **kwargs)
+
+    def _get_extra_module_parameters(self):
+        """Return extra parameters that should be passed to the module."""
+        params = super()._get_extra_module_parameters()
+        params["object_utility_module"] = functools.partial(
+            DenseNeuralNetwork,
+            hidden_layers=self.n_hidden,
+            units_per_hidden=self.n_units,
+            activation=self.activation(),
+            output_size=1,
+        )
+        return params

--- a/csrank/discretechoice/__init__.py
+++ b/csrank/discretechoice/__init__.py
@@ -9,6 +9,7 @@ from .multinomial_logit_model import MultinomialLogitModel
 from .nested_logit_model import NestedLogitModel
 from .paired_combinatorial_logit import PairedCombinatorialLogit
 from .pairwise_discrete_choice import PairwiseSVMDiscreteChoiceFunction
+from .ranknet_discrete_choice import RankNetDiscreteChoiceFunction
 
 __all__ = [
     "CmpNetDiscreteChoiceFunction",
@@ -22,4 +23,5 @@ __all__ = [
     "PairedCombinatorialLogit",
     "PairwiseSVMDiscreteChoiceFunction",
     "RandomBaselineDC",
+    "RankNetDiscreteChoiceFunction",
 ]

--- a/csrank/discretechoice/ranknet_discrete_choice.py
+++ b/csrank/discretechoice/ranknet_discrete_choice.py
@@ -1,0 +1,70 @@
+import functools
+
+import torch.nn as nn
+
+from csrank.discrete_choice_losses import CategoricalHingeLossMax
+from csrank.discretechoice.discrete_choice import SkorchDiscreteChoiceFunction
+from csrank.modules.object_mapping import DenseNeuralNetwork
+from csrank.modules.scoring.ranknet import RankNetScoring
+
+
+class RankNetDiscreteChoiceFunction(SkorchDiscreteChoiceFunction):
+    """A discrete choice estimator based on the RankNet-Approach.
+
+    See the documentation of the ``RankNetScoring`` class for more details.
+
+    Parameters
+    ----------
+    n_hidden : int
+        The number of hidden layers that should be used in the utility module.
+
+    n_units : int
+        The number of units per hidden layer that should be used in the utility
+        module.
+
+    choice_size : int
+        The size of the target choice set.
+
+    activation : torch activation function (class)
+        The activation function that should be used for each layer of the
+        comparative network.
+
+    criterion : torch criterion (class)
+        The criterion that is used to evaluate and optimize the module.
+
+    **kwargs : skorch NeuralNet arguments
+        All keyword arguments are passed to the constructor of
+        ``SkorchDiscreteChoiceFunction``. See the documentation of that class
+        for more details.
+    """
+
+    def __init__(
+        self,
+        n_hidden=2,
+        n_units=8,
+        activation=nn.ReLU,
+        choice_size=1,
+        criterion=CategoricalHingeLossMax,
+        **kwargs
+    ):
+        self.n_hidden = n_hidden
+        self.n_units = n_units
+        self.activation = activation
+        super().__init__(
+            module=RankNetScoring,
+            criterion=criterion,
+            choice_size=choice_size,
+            **kwargs
+        )
+
+    def _get_extra_module_parameters(self):
+        """Return extra parameters that should be passed to the module."""
+        params = super()._get_extra_module_parameters()
+        params["object_utility_module"] = functools.partial(
+            DenseNeuralNetwork,
+            hidden_layers=self.n_hidden,
+            units_per_hidden=self.n_units,
+            activation=self.activation(),
+            output_size=1,
+        )
+        return params

--- a/csrank/modules/scoring/__init__.py
+++ b/csrank/modules/scoring/__init__.py
@@ -12,5 +12,6 @@ examples.
 from .cmpnet import CmpNetScoring
 from .fate import FATEScoring
 from .feta import FETAScoring
+from .ranknet import RankNetScoring
 
-__all__ = ["CmpNetScoring", "FATEScoring", "FETAScoring"]
+__all__ = ["CmpNetScoring", "FATEScoring", "FETAScoring", "RankNetScoring"]

--- a/csrank/modules/scoring/ranknet.py
+++ b/csrank/modules/scoring/ranknet.py
@@ -1,0 +1,51 @@
+"""An implementation of the scoring module for CmpNet estimators."""
+
+import functools
+
+import torch.nn as nn
+
+from csrank.modules.object_mapping import DenseNeuralNetwork
+
+
+class RankNetScoring(nn.Module):
+    """Map instances to scores with the RankNet approach.
+
+    This approach learns a utility function that considers each object in
+    isolation, without taking context into account. It is similar to the
+    approach that was introduced in [1]_. This version trains the network based
+    on a loss function that evaluates the result (general/discrete choice or
+    ranking) as a whole. This differs from the version in [1]_, which proposes
+    to evaluate utilities on object pairs and train the network based on that.
+
+    Parameters
+    ----------
+    n_features: int
+        The number of features each object has.
+
+    object_utility_module: pytorch module with one integer parameter
+        The module that should be used for utility estimations. Uses a simple
+        linear mapping if not specified. You likely want to replace this with
+        something more expressive such as a ``DenseNeuralNetwork``. This should
+        take the size of the input values as its only parameter. You can use
+        ``functools.partial`` if necessary.
+
+    References
+    ----------
+    .. [1] Burges, C., Shaked, T., Renshaw, E., Lazier, A., Deeds, M.,
+    Hamilton, N., & Hullender, G. (2005, August). Learning to rank using
+    gradient descent. In Proceedings of the 22nd international conference on
+    Machine learning (pp. 89-96).
+    """
+
+    def __init__(
+        self,
+        n_features,
+        object_utility_module=functools.partial(
+            DenseNeuralNetwork, hidden_layers=3, units_per_hidden=20, ouput_features=1,
+        ),
+    ):
+        super().__init__()
+        self.object_utility_module = object_utility_module(n_features)
+
+    def forward(self, instances):
+        return self.object_utility_module(instances).squeeze(dim=-1)

--- a/csrank/objectranking/__init__.py
+++ b/csrank/objectranking/__init__.py
@@ -4,6 +4,7 @@ from .expected_rank_regression import ExpectedRankRegression
 from .fate_object_ranker import FATEObjectRanker
 from .feta_object_ranker import FETAObjectRanker
 from .rank_svm import RankSVM
+from .ranknet_object_ranker import RankNetObjectRanker
 
 __all__ = [
     "CmpNetObjectRanker",
@@ -11,5 +12,6 @@ __all__ = [
     "FATEObjectRanker",
     "FETAObjectRanker",
     "RandomBaselineRanker",
+    "RankNetObjectRanker",
     "RankSVM",
 ]

--- a/csrank/objectranking/ranknet_object_ranker.py
+++ b/csrank/objectranking/ranknet_object_ranker.py
@@ -1,0 +1,61 @@
+import functools
+
+import torch.nn as nn
+
+from csrank.modules.object_mapping import DenseNeuralNetwork
+from csrank.modules.scoring.ranknet import RankNetScoring
+from csrank.objectranking.object_ranker import SkorchObjectRanker
+from csrank.rank_losses import HingedRankLoss
+
+
+class RankNetObjectRanker(SkorchObjectRanker):
+    """A ranking estimator based on the RankNet-Approach.
+
+    See the documentation of the ``RankNetScoring`` class for more details.
+
+    Parameters
+    ----------
+    n_hidden : int
+        The number of hidden layers that should be used in the utility module.
+
+    n_units : int
+        The number of units per hidden layer that should be used in the utility
+        module.
+
+    activation : torch activation function (class)
+        The activation function that should be used for each layer of the
+        comparative network.
+
+    criterion : torch criterion (class)
+        The criterion that is used to evaluate and optimize the module.
+
+    **kwargs : skorch NeuralNet arguments
+        All keyword arguments are passed to the constructor of
+        ``SkorchObjectRanker``. See the documentation of that class for more
+        details.
+    """
+
+    def __init__(
+        self,
+        n_hidden=2,
+        n_units=8,
+        criterion=HingedRankLoss,
+        activation=nn.SELU,
+        **kwargs
+    ):
+        self.n_hidden = n_hidden
+        self.n_units = n_units
+        self.activation = activation
+        super().__init__(module=RankNetScoring, criterion=criterion, **kwargs)
+
+    def _get_extra_module_parameters(self):
+        """Return extra parameters that should be passed to the module."""
+        params = super()._get_extra_module_parameters()
+        params["object_utility_module"] = functools.partial(
+            DenseNeuralNetwork,
+            hidden_layers=self.n_hidden,
+            units_per_hidden=self.n_units,
+            activation=self.activation(),
+            output_size=1,
+        )
+        return params

--- a/csrank/objectranking/ranknet_object_ranker.py
+++ b/csrank/objectranking/ranknet_object_ranker.py
@@ -39,8 +39,8 @@ class RankNetObjectRanker(SkorchObjectRanker):
         self,
         n_hidden=2,
         n_units=8,
-        criterion=HingedRankLoss,
         activation=nn.SELU,
+        criterion=HingedRankLoss,
         **kwargs
     ):
         self.n_hidden = n_hidden

--- a/csrank/tests/test_choice_functions.py
+++ b/csrank/tests/test_choice_functions.py
@@ -9,10 +9,12 @@ from csrank.choicefunction import FATEChoiceFunction
 from csrank.choicefunction import FETAChoiceFunction
 from csrank.choicefunction import GeneralizedLinearModel
 from csrank.choicefunction import PairwiseSVMChoiceFunction
+from csrank.choicefunction import RankNetChoiceFunction
 from csrank.constants import CMPNET_CHOICE
 from csrank.constants import FATE_CHOICE
 from csrank.constants import FETA_CHOICE
 from csrank.constants import GLM_CHOICE
+from csrank.constants import RANKNET_CHOICE
 from csrank.constants import RANKSVM_CHOICE
 from csrank.metrics_np import auc_score
 from csrank.metrics_np import f1_measure
@@ -88,6 +90,11 @@ choice_functions = {
             **skorch_common_args,
         },
         get_vals([0.9368, 0.9617, 1.0]),
+    ),
+    RANKNET_CHOICE: (
+        RankNetChoiceFunction,
+        skorch_common_args.copy(),
+        get_vals([0.9202, 0.9198, 1.0]),
     ),
 }
 

--- a/csrank/tests/test_discrete_choice.py
+++ b/csrank/tests/test_discrete_choice.py
@@ -12,6 +12,7 @@ from csrank.constants import MLM
 from csrank.constants import MNL
 from csrank.constants import NLM
 from csrank.constants import PCL
+from csrank.constants import RANKNET_DC
 from csrank.constants import RANKSVM_DC
 from csrank.dataset_reader.discretechoice.util import convert_to_label_encoding
 from csrank.discretechoice import CmpNetDiscreteChoiceFunction
@@ -23,6 +24,7 @@ from csrank.discretechoice import MultinomialLogitModel
 from csrank.discretechoice import NestedLogitModel
 from csrank.discretechoice import PairedCombinatorialLogit
 from csrank.discretechoice import PairwiseSVMDiscreteChoiceFunction
+from csrank.discretechoice import RankNetDiscreteChoiceFunction
 from csrank.metrics_np import categorical_accuracy_np
 from csrank.metrics_np import subset_01_loss
 from csrank.metrics_np import topk_categorical_accuracy_np
@@ -92,6 +94,11 @@ discrete_choice_functions = {
     PCL: (PairedCombinatorialLogit, {}, get_vals()),
     GEV: (GeneralizedNestedLogitModel, {}, get_vals()),
     MLM: (MixedLogitModel, {}, get_vals()),
+    RANKNET_DC: (
+        RankNetDiscreteChoiceFunction,
+        skorch_common_args.copy(),
+        get_vals([1.0, 1.0]),
+    ),
     RANKSVM_DC: (PairwiseSVMDiscreteChoiceFunction, {}, get_vals([0.982, 0.982])),
 }
 

--- a/csrank/tests/test_ranking.py
+++ b/csrank/tests/test_ranking.py
@@ -7,6 +7,7 @@ from csrank.constants import CMPNET
 from csrank.constants import ERR
 from csrank.constants import FATE_RANKER
 from csrank.constants import FETA_RANKER
+from csrank.constants import RANKNET
 from csrank.constants import RANKSVM
 from csrank.metrics_np import zero_one_accuracy_np
 from csrank.metrics_np import zero_one_rank_loss_for_scores_ties_np
@@ -14,6 +15,7 @@ from csrank.objectranking import CmpNetObjectRanker
 from csrank.objectranking import ExpectedRankRegression
 from csrank.objectranking import FATEObjectRanker
 from csrank.objectranking import FETAObjectRanker
+from csrank.objectranking import RankNetObjectRanker
 from csrank.objectranking import RankSVM
 
 skorch_common_args = {
@@ -67,6 +69,7 @@ object_rankers = {
         },
         (0.0, 1.0),
     ),
+    RANKNET: (RankNetObjectRanker, skorch_common_args.copy(), (0.0, 1.0)),
 }
 
 


### PR DESCRIPTION
## Description

This adds pytorch versions of the CmpNet estimators.

## Motivation and Context

Part of the ongoing pytorch migration.

## How Has This Been Tested?

I have added the RankNet estimators to the existing tests for discrete choice, general choice and object ranking. I have checked the changes with our set of linters and the test suite.

## Does this close/impact existing issues?

Related to #125.

## Types of changes

This depends on what you consider as the base. It is a new feature for the pytorch migration branch, but a breaking change on master.
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
